### PR TITLE
Bug/order of elements in form groups

### DIFF
--- a/backend/app/question_service.py
+++ b/backend/app/question_service.py
@@ -46,11 +46,16 @@ class QuestionService:
 
     @staticmethod
     def get_meta(questionnaire, relationship):
+        __tablename__ = "identification_questionnaire"
+        __label__ = "Identification"
+        __question_type__ = QuestionService.TYPE_IDENTIFYING
+
         meta = {"table": {}}
-        if 'question_type' in meta['table']:
+        try:
             meta["table"]['question_type'] = questionnaire.__question_type__
-        if 'label' in meta['table']:
             meta["table"]["label"] = questionnaire.__label__
+        except:
+            pass  # If these fields don't exist, just keep going.
         meta["fields"] = []
 
         groups = questionnaire.get_field_groups()
@@ -69,11 +74,15 @@ class QuestionService:
                             values['fields'].remove(c.name)
                             if'fieldGroup' not in values: values['fieldGroup'] = []
                             values['fieldGroup'].append(c.info)
+                            values['fieldGroup'] = sorted(values['fieldGroup'],
+                                                          key=lambda field: field['display_order'])
                             added = True
+                    # Sort the fields
+
                 if not added:
                     meta['fields'].append(c.info)
 
-        for group,values in groups.items():
+        for group, values in groups.items():
             values['name'] = group
 #            if value['type'] == 'repeat':
 #                value['fieldArray'] = value.pop('fields')
@@ -86,15 +95,8 @@ class QuestionService:
                 values['fieldArray'] = {'fieldGroup': values.pop('fields')}
             meta['fields'].append(values)
 
-
-  #      try:
-   #         meta = questionnaire.update_meta(meta)
-#        except AttributeError:
-            # Questionnaire doesn't have to implement this method.
- #           pass
-
-
-        # Rename filed_groups to be "
+        # Sort the fields
+        meta['fields'] = sorted(meta['fields'], key=lambda field: field['display_order'])
 
         # loops through the depths, checks, and replaces ....
         meta_relationed = QuestionService._recursive_relationship_changes(meta, relationship)

--- a/frontend/src/app/flow/flow.component.ts
+++ b/frontend/src/app/flow/flow.component.ts
@@ -163,7 +163,6 @@ export class FlowComponent implements OnInit {
       fields.push(keysToCamel(field));
 
     }
-    fields.sort((f1, f2) => f1.displayOrder - f2.displayOrder);
     return fields;
   }
 


### PR DESCRIPTION
This fixes the problem that was surfacing under the support services where the order of grouped form elements was incorrect.  Moved sorting of elements to take place on the server side and incorporated it into the recursion of fields so that sort order is handled all the way down.  