### PR TITLE
Feature/admin data view

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -89,6 +89,10 @@ def _load_data(data_loader):
     data_loader.load_identification_questionnaire()
     data_loader.load_professional_profile_questionnaire()
     data_loader.load_supports_questionnaire()
+    data_loader.load_assistive_devices()
+    data_loader.load_housemate()
+    data_loader.load_medication()
+    data_loader.load_therapy()
 
 
 @app.cli.command()

--- a/backend/app/data_loader.py
+++ b/backend/app/data_loader.py
@@ -175,7 +175,7 @@ class DataLoader():
         db.session.commit()
 
     def load_contact_questionnaire(self):
-        c_ques = ContactQuestionnaire(phone=555-555-1234, contact_times='Weekdays at 5AM', email='charlie@brown.com')
+        c_ques = ContactQuestionnaire(phone='555-555-1234', contact_times='Weekdays at 5AM', email='charlie@brown.com')
         db.session.add(c_ques)
         print("Contact loaded.  There is now %i contact record in the database." % db.session.query(
             ContactQuestionnaire).count())

--- a/backend/app/data_loader.py
+++ b/backend/app/data_loader.py
@@ -168,7 +168,7 @@ class DataLoader():
 
 
     def load_clinical_diagnoses_questionnaire(self):
-        cd_ques = ClinicalDiagnosesQuestionnaire(mental_health='ptsd', genetic='angelman')
+        cd_ques = ClinicalDiagnosesQuestionnaire(mental_health=['ptsd'], genetic=['angelman'])
         db.session.add(cd_ques)
         print("Clinical Diagnoses loaded. There is now %i clinical diagnoses record in the database." % db.session.query(
             ClinicalDiagnosesQuestionnaire).count())
@@ -194,7 +194,7 @@ class DataLoader():
 
     def load_demographics_questionnaire(self):
         d_ques = DemographicsQuestionnaire(user_id=1, birth_sex='male', gender_identity='intersex',
-                                           race_ethnicity="raceAsian")
+                                           race_ethnicity=["raceAsian"])
         db.session.add(d_ques)
         print("Demographics loaded.  There is now %i demographics record in the database." % db.session.query(
             DemographicsQuestionnaire).count())
@@ -237,7 +237,7 @@ class DataLoader():
         db.session.commit()
 
     def load_home_questionnaires(self):
-        h_ques = HomeDependentQuestionnaire(dependent_living_situation="fullTimeGuardian", struggle_to_afford=True)
+        h_ques = HomeDependentQuestionnaire(dependent_living_situation=["fullTimeGuardian"], struggle_to_afford=True)
         db.session.add(h_ques)
         print("Home for Dependents loaded.  There is now %i dependent home record in the database." % db.session.query(
             HomeDependentQuestionnaire).count())

--- a/backend/app/data_loader.py
+++ b/backend/app/data_loader.py
@@ -186,7 +186,7 @@ class DataLoader():
         db.session.add(cb_dques)
         print("Current Behaviors for Dependents loaded.  There is now %i dependent current behavior record in the database." % db.session.query(
             CurrentBehaviorsDependentQuestionnaire).count())
-        cb_sques = CurrentBehaviorsSelfQuestionnaire(self_verbal_ability='nonVerbal', has_academic_difficulties=True)
+        cb_sques = CurrentBehaviorsSelfQuestionnaire(self_verbal_ability=["nonVerbal"], has_academic_difficulties=True)
         db.session.add(cb_sques)
         print("Current Behaviors for Self participants loaded.  There is now %i self current behavior record in the database." % db.session.query(
             CurrentBehaviorsSelfQuestionnaire).count())

--- a/backend/app/data_loader.py
+++ b/backend/app/data_loader.py
@@ -270,6 +270,34 @@ class DataLoader():
             SupportsQuestionnaire).count())
         db.session.commit()
 
+    def load_assistive_devices(self):
+        ad = AssistiveDevice()
+        db.session.add(ad)
+        print("Assistive Device loaded.  There is now %i assistive device record in the database." % db.session.query(
+            AssistiveDevice).count())
+        db.session.commit()
+
+    def load_housemate(self):
+        hm = Housemate()
+        db.session.add(hm)
+        print("Housemate loaded.  There is now %i housemate record in the database." % db.session.query(
+            Housemate).count())
+        db.session.commit()
+
+    def load_medication(self):
+        m = Medication()
+        db.session.add(m)
+        print("Medication loaded.  There is now %i medication record in the database." % db.session.query(
+            Medication).count())
+        db.session.commit()
+
+    def load_therapy(self):
+        t = Therapy()
+        db.session.add(t)
+        print("Therapy loaded.  There is now %i therapy record in the database." % db.session.query(
+            Therapy).count())
+        db.session.commit()
+
     def get_org_by_name(self, org_name):
         organization = db.session.query(Organization).filter(Organization.name == org_name).first()
         if organization is None:

--- a/backend/app/model/questionnaires/home_self_questionnaire.py
+++ b/backend/app/model/questionnaires/home_self_questionnaire.py
@@ -52,7 +52,7 @@ class HomeSelfQuestionnaire(db.Model, HomeMixin):
                     "fields": ["self_living_situation", "self_living_other"],
                     "display_order": 1,
                     "wrappers": ["card"],
-                    "template_options": {"label": "Where do your currently live?"},
+                    "template_options": {"label": "Where do you currently live?"},
                 }
         return field_groups
 

--- a/backend/app/question_service.py
+++ b/backend/app/question_service.py
@@ -12,7 +12,7 @@ class QuestionService:
 
     @staticmethod
     def get_class(name):
-        module_name = QuestionService.QUESTION_PACKAGE + "." + name;
+        module_name = QuestionService.QUESTION_PACKAGE + "." + name
         class_name = QuestionService.camel_case_it(name)
         return QuestionService.str_to_class(module_name, class_name)
 
@@ -20,7 +20,7 @@ class QuestionService:
     def get_schema(name, many=False, session=None):
         module_name = QuestionService.QUESTION_PACKAGE + "." + name
         schema_name = QuestionService.camel_case_it(name) + "Schema"
-        return QuestionService.str_to_class(module_name, schema_name)(many=many,session=session)
+        return QuestionService.str_to_class(module_name, schema_name)(many=many, session=session)
 
     @staticmethod
     def camel_case_it(name):
@@ -46,10 +46,6 @@ class QuestionService:
 
     @staticmethod
     def get_meta(questionnaire, relationship):
-        __tablename__ = "identification_questionnaire"
-        __label__ = "Identification"
-        __question_type__ = QuestionService.TYPE_IDENTIFYING
-
         meta = {"table": {}}
         try:
             meta["table"]['question_type'] = questionnaire.__question_type__

--- a/backend/app/resources/QuestionnaireEndpoint.py
+++ b/backend/app/resources/QuestionnaireEndpoint.py
@@ -88,6 +88,8 @@ class QuestionnaireListMetaEndpoint(flask_restful.Resource):
                 c.info['name'] = c.name
                 c.info['key'] = c.name
                 meta['fields'].append(c.info)
+            elif c.type.python_type == datetime.datetime:
+                meta['fields'].append({'name': c.name, 'key': c.name, 'display_order': 0, 'type': 'DATETIME'})
             else:
                 meta['fields'].append({'name': c.name, 'key': c.name, 'display_order': 0})
 

--- a/backend/app/resources/QuestionnaireEndpoint.py
+++ b/backend/app/resources/QuestionnaireEndpoint.py
@@ -4,6 +4,8 @@ import os
 from flask import request
 from sqlalchemy.exc import IntegrityError
 from app import db, RestException, auth
+from app.model.user import Role
+from app.wrappers import requires_roles
 
 # The Questionnaire Endpoint expects a "type" that is the exact Class name of a file
 # located in the Questionnaire Package. It should have the following properties:
@@ -58,6 +60,7 @@ class QuestionnaireEndpoint(flask_restful.Resource):
 class QuestionnaireListEndpoint(flask_restful.Resource):
 
     @auth.login_required
+    @requires_roles(Role.admin)
     def get(self, name):
         class_ref = QuestionService.get_class(name)
         schema = QuestionService.get_schema(name, many=True)

--- a/backend/app/resources/QuestionnaireEndpoint.py
+++ b/backend/app/resources/QuestionnaireEndpoint.py
@@ -1,5 +1,6 @@
 import datetime
 import flask_restful
+import os
 from flask import request
 from sqlalchemy.exc import IntegrityError
 from app import db, RestException, auth
@@ -61,3 +62,18 @@ class QuestionnaireListEndpoint(flask_restful.Resource):
         schema = QuestionService.get_schema(name, many=True)
         questionnaires = db.session.query(class_ref).all()
         return schema.dump(questionnaires)
+
+
+class QuestionnaireNamesEndpoint(flask_restful.Resource):
+
+    def get(self):
+        all_file_names = os.listdir('./app/model/questionnaires')
+        non_questionnaires = ['mixin', '__']
+        questionnaire_file_names = []
+        for index, file_name in enumerate(all_file_names):
+            if any(string in file_name for string in non_questionnaires):
+                pass
+            else:
+                f = file_name.replace(".py", "")
+                questionnaire_file_names.append(f)
+        return questionnaire_file_names

--- a/backend/app/resources/QuestionnaireEndpoint.py
+++ b/backend/app/resources/QuestionnaireEndpoint.py
@@ -54,4 +54,10 @@ class QuestionnaireEndpoint(flask_restful.Resource):
         return schema.dump(updated)
 
 
+class QuestionnaireListEndpoint(flask_restful.Resource):
 
+    def get(self, name):
+        class_ref = QuestionService.get_class(name)
+        schema = QuestionService.get_schema(name, many=True)
+        questionnaires = db.session.query(class_ref).all()
+        return schema.dump(questionnaires)

--- a/backend/app/resources/QuestionnaireEndpoint.py
+++ b/backend/app/resources/QuestionnaireEndpoint.py
@@ -57,6 +57,7 @@ class QuestionnaireEndpoint(flask_restful.Resource):
 
 class QuestionnaireListEndpoint(flask_restful.Resource):
 
+    @auth.login_required
     def get(self, name):
         class_ref = QuestionService.get_class(name)
         schema = QuestionService.get_schema(name, many=True)

--- a/backend/app/resources/QuestionnaireEndpoint.py
+++ b/backend/app/resources/QuestionnaireEndpoint.py
@@ -80,4 +80,4 @@ class QuestionnaireNamesEndpoint(flask_restful.Resource):
             else:
                 f = file_name.replace(".py", "")
                 questionnaire_file_names.append(f)
-        return questionnaire_file_names
+        return sorted(questionnaire_file_names)

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -35,7 +35,8 @@ from app.resources.OrganizationEndpoint import (
 )
 from app.resources.QuestionnaireEndpoint import (
     QuestionnaireEndpoint,
-    QuestionnaireListEndpoint
+    QuestionnaireListEndpoint,
+    QuestionnaireNamesEndpoint
 )
 from app.resources.SessionStatusEndpoint import SessionStatusEndpoint
 from app.resources.StudyAndCategoryEndpoint import (
@@ -136,6 +137,7 @@ endpoints = [
     # Participants
     (ParticipantEndpoint, "/participant/<id>"),
     # Questionnaires
+    (QuestionnaireNamesEndpoint, "/q"),
     (QuestionnaireListEndpoint, "/q/<string:name>"),
     (QuestionnaireEndpoint, "/q/<string:name>/<string:id>"),
     # Flow Endpoint

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -36,6 +36,7 @@ from app.resources.OrganizationEndpoint import (
 from app.resources.QuestionnaireEndpoint import (
     QuestionnaireEndpoint,
     QuestionnaireListEndpoint,
+    QuestionnaireListMetaEndpoint,
     QuestionnaireNamesEndpoint
 )
 from app.resources.SessionStatusEndpoint import SessionStatusEndpoint
@@ -139,6 +140,7 @@ endpoints = [
     # Questionnaires
     (QuestionnaireNamesEndpoint, "/q"),
     (QuestionnaireListEndpoint, "/q/<string:name>"),
+    (QuestionnaireListMetaEndpoint, "/q/<string:name>/meta"),
     (QuestionnaireEndpoint, "/q/<string:name>/<string:id>"),
     # Flow Endpoint
     (FlowEndpoint, "/flow/<string:name>/<string:participant_id>"),

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -34,7 +34,8 @@ from app.resources.OrganizationEndpoint import (
     OrganizationListEndpoint
 )
 from app.resources.QuestionnaireEndpoint import (
-    QuestionnaireEndpoint
+    QuestionnaireEndpoint,
+    QuestionnaireListEndpoint
 )
 from app.resources.SessionStatusEndpoint import SessionStatusEndpoint
 from app.resources.StudyAndCategoryEndpoint import (
@@ -135,6 +136,7 @@ endpoints = [
     # Participants
     (ParticipantEndpoint, "/participant/<id>"),
     # Questionnaires
+    (QuestionnaireListEndpoint, "/q/<string:name>"),
     (QuestionnaireEndpoint, "/q/<string:name>/<string:id>"),
     # Flow Endpoint
     (FlowEndpoint, "/flow/<string:name>/<string:participant_id>"),

--- a/backend/tests.py
+++ b/backend/tests.py
@@ -247,8 +247,8 @@ class TestCase(unittest.TestCase):
         self.assertEqual(db_ad.description, ad.description)
         return db_ad
 
-    def construct_clinical_diagnoses_questionnaire(self, developmental='speechLanguage', mental_health='ocd',
-                                                   medical='insomnia', genetic='corneliaDeLange', participant=None,
+    def construct_clinical_diagnoses_questionnaire(self, developmental=['speechLanguage'], mental_health=['ocd'],
+                                                   medical=['insomnia'], genetic=['corneliaDeLange'], participant=None,
                                                    user=None):
 
         cdq = ClinicalDiagnosesQuestionnaire(developmental=developmental, mental_health=mental_health, medical=medical,
@@ -297,9 +297,9 @@ class TestCase(unittest.TestCase):
         return db_cq
 
     def construct_current_behaviors_dependent_questionnaire(self, dependent_verbal_ability='fluent',
-                                                            concerning_behaviors='hoarding',
+                                                            concerning_behaviors=['hoarding'],
                                                             has_academic_difficulties=True,
-                                                            academic_difficulty_areas='math',
+                                                            academic_difficulty_areas=['math'],
                                                             participant=None, user=None):
 
         cb = CurrentBehaviorsDependentQuestionnaire(dependent_verbal_ability=dependent_verbal_ability,
@@ -3093,12 +3093,12 @@ class TestCase(unittest.TestCase):
                           content_type="application/json", headers=self.logged_in_headers())
         self.assertSuccess(rv)
         response = json.loads(rv.get_data(as_text=True))
-        intro = self.get_field_from_response(response, "intro");
+        intro = self.get_field_from_response(response, "intro")
         self.assertIsNotNone(intro["template_options"]["description"])
         self.assertEqual(intro["template_options"]["description"],
                          "Please answer the following questions about yourself (* indicates required response):")
 
-        birth_city = self.get_field_from_response(response, "birth_city");
+        birth_city = self.get_field_from_response(response, "birth_city")
         self.assertIsNotNone(birth_city)
         self.assertIsNotNone(birth_city["template_options"])
         self.assertIsNotNone(birth_city["template_options"]["label"])
@@ -3110,7 +3110,7 @@ class TestCase(unittest.TestCase):
                           content_type="application/json", headers=self.logged_in_headers())
         self.assertSuccess(rv)
         response = json.loads(rv.get_data(as_text=True))
-        birth_city = self.get_field_from_response(response, "birth_city");
+        birth_city = self.get_field_from_response(response, "birth_city")
         self.assertIsNotNone(birth_city["template_options"]["label"])
         self.assertEqual(birth_city["template_options"]["label"],
                          "Your child's city/municipality of birth")
@@ -3208,9 +3208,56 @@ class TestCase(unittest.TestCase):
                           content_type="application/json", headers=self.logged_in_headers())
         self.assertSuccess(rv)
         response = json.loads(rv.get_data(as_text=True))
-        self.assertEqual(1,  response["fields"][0]["display_order"])
-        self.assertEqual(2,  response["fields"][1]["display_order"])
-        self.assertEqual(3,  response["fields"][2]["display_order"])
+        self.assertEqual(1, response["fields"][0]["display_order"])
+        self.assertEqual(2, response["fields"][1]["display_order"])
+        self.assertEqual(3, response["fields"][2]["display_order"])
 
-        self.assertEqual(6.1, response['fields'][4]["fieldGroup"][0]["display_order"]);
-        self.assertEqual(6.2, response['fields'][4]["fieldGroup"][1]["display_order"]);
+        self.assertEqual(6.1, response['fields'][4]["fieldGroup"][0]["display_order"])
+        self.assertEqual(6.2, response['fields'][4]["fieldGroup"][1]["display_order"])
+
+    def test_questionnaire_names_list_basics(self):
+        rv = self.app.get('/api/q',
+                          follow_redirects=True,
+                          content_type="application/json")
+        self.assertSuccess(rv)
+        response = json.loads(rv.get_data(as_text=True))
+        self.assertEqual("assistive_device", response[0])
+        self.assertEqual("education_dependent_questionnaire", response[7])
+        self.assertEqual("home_self_questionnaire", response[13])
+        self.assertEqual("therapy", response[19])
+        self.assertEqual(20, len(response))
+
+    def test_questionnaire_list_meta_basics(self):
+        self.construct_education_self_questionnaire()
+        rv = self.app.get('/api/q/education_self_questionnaire/meta',
+                          follow_redirects=True,
+                          content_type="application/json")
+        self.assertSuccess(rv)
+        response = json.loads(rv.get_data(as_text=True))
+        self.assertEqual("id", response["fields"][0]["name"])
+        self.assertEqual("user_id", response["fields"][4]["name"])
+        self.assertEqual("school_type", response["fields"][7]["name"])
+        self.assertEqual("school_services_other", response["fields"][12]["name"])
+        self.assertEqual(13, len(response["fields"]))
+
+    def test_questionnaire_list_basics(self):
+        self.construct_current_behaviors_dependent_questionnaire()
+        rv = self.app.get('/api/q/current_behaviors_dependent_questionnaire',
+                          follow_redirects=True,
+                          content_type="application/json", headers=self.logged_in_headers())
+        self.assertSuccess(rv)
+        response = json.loads(rv.get_data(as_text=True))
+        self.assertEqual(["math"], response[0]["academic_difficulty_areas"])
+        self.assertEqual("fluent", response[0]["dependent_verbal_ability"])
+        self.assertEqual(1, response[0]["id"])
+
+    def test_non_admin_cannot_view_questionnaire_list(self):
+        user = self.construct_user(email='regularUser@user.com')
+        admin = self.construct_admin_user(email='adminUser@user.com')
+        self.construct_contact_questionnaire()
+        rv = self.app.get('/api/q/contact_questionnaire', content_type="application/json")
+        self.assertEqual(401, rv.status_code)
+        rv = self.app.get('/api/q/contact_questionnaire', content_type="application/json", headers=self.logged_in_headers(user=user))
+        self.assertEqual(403, rv.status_code)
+        rv = self.app.get('/api/q/contact_questionnaire', content_type="application/json", headers=self.logged_in_headers(user=admin))
+        self.assertSuccess(rv)

--- a/frontend/src/app/_models/questionnaire_data_source.ts
+++ b/frontend/src/app/_models/questionnaire_data_source.ts
@@ -1,0 +1,34 @@
+import {Step} from './step';
+import {DataSource} from '@angular/cdk/table';
+import {BehaviorSubject} from 'rxjs/internal/BehaviorSubject';
+import {ApiService} from '../_services/api/api.service';
+import {CollectionViewer} from '@angular/cdk/collections';
+import {Observable} from 'rxjs/internal/Observable';
+
+export class QuestionnaireDataSource implements DataSource<Step> {
+
+  private stepSubject = new BehaviorSubject<any>([]);
+  private countSubject = new BehaviorSubject<number>(0);
+  private loadingSubject = new BehaviorSubject<boolean>(false);
+
+  constructor(private api: ApiService) {}
+
+  connect(collectionViewer: CollectionViewer): Observable<Step[]> {
+    return this.stepSubject.asObservable();
+  }
+
+  disconnect(collectionViewer: CollectionViewer): void {
+    this.stepSubject.complete();
+    this.loadingSubject.complete();
+    this.countSubject.complete();
+  }
+
+  loadQuestionnaires(questionnaire_name) {
+    this.loadingSubject.next(true);
+    this.api.getQuestionnaireList(questionnaire_name).subscribe(
+      results => {
+        this.stepSubject.next(results)
+      }
+    )
+  }
+}

--- a/frontend/src/app/_models/user.ts
+++ b/frontend/src/app/_models/user.ts
@@ -8,6 +8,7 @@ export class User {
   participants?: Participant[];
   last_updated?: Date;
   token?: string;
+  role?: string;
 
   constructor(private _props) {
     for (const propName in this._props) {

--- a/frontend/src/app/_routing/admin-guard.ts
+++ b/frontend/src/app/_routing/admin-guard.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Router, CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { AuthenticationService } from '../_services/api/authentication-service';
+
+
+@Injectable({ providedIn: 'root' })
+export class AdminGuard implements CanActivate {
+  constructor(
+    private router: Router,
+    private authenticationService: AuthenticationService
+  ) { }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    const currentUser = this.authenticationService.currentUserValue;
+    if (currentUser && currentUser.role == 'admin') {
+      return true;
+    }
+    if (currentUser && currentUser.role == 'user') {
+      // not admin so redirect to user profile page with the return url
+    this.router.navigate(['/profile']);
+    return false;
+    }
+
+    // not logged in so redirect to login page with the return url
+    this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
+    return false;
+  }
+
+}

--- a/frontend/src/app/_routing/routing.module.ts
+++ b/frontend/src/app/_routing/routing.module.ts
@@ -19,7 +19,8 @@ import { FlowComponent } from '../flow/flow.component';
 import { TimedoutComponent } from '../timed-out/timed-out.component';
 import { LogoutComponent } from '../logout/logout.component';
 import { FlowCompleteComponent } from '../flow-complete/flow-complete.component';
-import {AuthGuard} from './auth-guard';
+import { AuthGuard } from './auth-guard';
+import { AdminGuard } from './admin-guard';
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -43,7 +44,7 @@ const routes: Routes = [
   { path: 'logout', component: LogoutComponent, data: { title: 'You have been logged out.', hideHeader: true } },
   { path: 'timedout', component: TimedoutComponent, data: { title: 'Your session has timed out.', hideHeader: true } },
   { path: 'training/:trainingId', component: TrainingDetailComponent, data: { title: 'Training Details' } },
-  { path: 'admin', component: AdminHomeComponent, data: { title: 'Admin' }, canActivate: [AuthGuard] },
+  { path: 'admin', component: AdminHomeComponent, data: { title: 'Admin' }, canActivate: [AdminGuard] },
 ];
 
 @NgModule({

--- a/frontend/src/app/_routing/routing.module.ts
+++ b/frontend/src/app/_routing/routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AdminHomeComponent } from '../admin-home/admin-home.component';
 import { EnrollComponent } from '../enroll/enroll.component';
 import { ForgotPasswordComponent } from '../forgot-password/forgot-password.component';
 import { HomeComponent } from '../home/home.component';
@@ -31,8 +32,8 @@ const routes: Routes = [
     data: { title: 'Reset your STAR Drive password', hideHeader: true }
   },
   { path: 'profile', component: ProfileComponent, data: { title: 'Your STAR Drive Account' }, canActivate: [AuthGuard] },
-  { path: 'flow/complete', component: FlowCompleteComponent, data: { title: 'Enrollment application complete' } , canActivate: [AuthGuard]},
-  { path: 'flow/:flowName/:participantId', component: FlowComponent, data: { title: 'Your STAR Drive Account' } , canActivate: [AuthGuard]},
+  { path: 'flow/complete', component: FlowCompleteComponent, data: { title: 'Enrollment application complete' }, canActivate: [AuthGuard] },
+  { path: 'flow/:flowName/:participantId', component: FlowComponent, data: { title: 'Your STAR Drive Account' }, canActivate: [AuthGuard] },
   { path: 'register', component: RegisterComponent, data: { title: 'Create a STAR Drive Account', hideHeader: true } },
   { path: 'resources', component: ResourcesComponent, data: { title: 'View STAR Drive Trainings & Resources' } },
   { path: 'resource/:resourceId', component: ResourceDetailComponent, data: { title: 'Resource Details' } },
@@ -42,6 +43,7 @@ const routes: Routes = [
   { path: 'logout', component: LogoutComponent, data: { title: 'You have been logged out.', hideHeader: true } },
   { path: 'timedout', component: TimedoutComponent, data: { title: 'Your session has timed out.', hideHeader: true } },
   { path: 'training/:trainingId', component: TrainingDetailComponent, data: { title: 'Training Details' } },
+  { path: 'admin', component: AdminHomeComponent, data: { title: 'Admin' }, canActivate: [AuthGuard] },
 ];
 
 @NgModule({

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -33,6 +33,7 @@ export class ApiService {
     participant: '/api/participant/<id>',
     questionnaire: '/api/q/<name>/<id>',
     questionnaireList: '/api/q/<name>',
+    questionnaireListMeta: '/api/q/<name>/meta',
     questionnaireNames: '/api/q',
     questionnairemeta: '/api/flow/<flow>/<questionnaire_name>/meta',
     resourcebycategory: '/api/category/<category_id>/resource',
@@ -253,6 +254,15 @@ export class ApiService {
   getQuestionnaireList(name: string) {
     const url = this
       ._endpointUrl('questionnaireList')
+      .replace('<name>', name);
+    return this.httpClient.get<object>(url)
+      .pipe(catchError(this._handleError));
+  }
+
+  /** getQuestionnaireListMeta */
+  getQuestionnaireListMeta(name: string) {
+    const url = this
+      ._endpointUrl('questionnaireListMeta')
       .replace('<name>', name);
     return this.httpClient.get<object>(url)
       .pipe(catchError(this._handleError));

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -33,6 +33,7 @@ export class ApiService {
     participant: '/api/participant/<id>',
     questionnaire: '/api/q/<name>/<id>',
     questionnaireList: '/api/q/<name>',
+    questionnaireNames: '/api/q',
     questionnairemeta: '/api/flow/<flow>/<questionnaire_name>/meta',
     resourcebycategory: '/api/category/<category_id>/resource',
     resourcecategory: '/api/resource_category/<id>',
@@ -238,6 +239,14 @@ export class ApiService {
       .pipe(
         map(json => new User(json)),
         catchError(this._handleError));
+  }
+
+  /** getQuestionnaireNames */
+  getQuestionnaireNames() {
+    const url = this
+      ._endpointUrl('questionnaireNames');
+    return this.httpClient.get<any>(url)
+      .pipe(catchError(this._handleError));
   }
 
   /** getQuestionnaireList */

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -32,6 +32,7 @@ export class ApiService {
     participantbysession: '/api/session/participant',
     participant: '/api/participant/<id>',
     questionnaire: '/api/q/<name>/<id>',
+    questionnaireList: '/api/q/<name>',
     questionnairemeta: '/api/flow/<flow>/<questionnaire_name>/meta',
     resourcebycategory: '/api/category/<category_id>/resource',
     resourcecategory: '/api/resource_category/<id>',
@@ -239,7 +240,16 @@ export class ApiService {
         catchError(this._handleError));
   }
 
-  /** submitQuestionnaire */
+  /** getQuestionnaireList */
+  getQuestionnaireList(name: string) {
+    const url = this
+      ._endpointUrl('questionnaireList')
+      .replace('<name>', name);
+    return this.httpClient.get<object>(url)
+      .pipe(catchError(this._handleError));
+  }
+
+  /** getQuestionnaire */
   getQuestionnaire(name: string, id: number) {
     const url = this
       ._endpointUrl('questionnaire')

--- a/frontend/src/app/admin-home/admin-home.component.html
+++ b/frontend/src/app/admin-home/admin-home.component.html
@@ -1,5 +1,1 @@
-<div *ngFor="let qn of questionnaire_names">
-  <app-questionnaire-data-table
-    [questionnaire_name]="qn"
-  ></app-questionnaire-data-table>
-</div>
+<app-questionnaire-data-view></app-questionnaire-data-view>

--- a/frontend/src/app/admin-home/admin-home.component.html
+++ b/frontend/src/app/admin-home/admin-home.component.html
@@ -1,13 +1,5 @@
-<mat-table
-  [dataSource]="dataSource"
->
-  <!--Column-->
-  <div *ngFor="let column of displayedColumns">
-    <ng-container matColumnDef={{column}}>
-      <th mat-header-cell *matHeaderCellDef> {{ snakeToUpperCase(column) }} </th>
-      <td mat-cell *matCellDef="let element" > {{element[column]}} </td>
-    </ng-container>
-  </div>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let element; columns: displayedColumns;"></tr>
-</mat-table>
+<div *ngFor="let qn of questionnaire_names">
+  <app-questionnaire-data-table
+    [questionnaire_name]="qn"
+  ></app-questionnaire-data-table>
+</div>

--- a/frontend/src/app/admin-home/admin-home.component.html
+++ b/frontend/src/app/admin-home/admin-home.component.html
@@ -1,0 +1,13 @@
+<mat-table
+  [dataSource]="dataSource"
+>
+  <!--Column-->
+  <div *ngFor="let column of displayedColumns">
+    <ng-container matColumnDef={{column}}>
+      <th mat-header-cell *matHeaderCellDef> {{column}} </th>
+      <td mat-cell *matCellDef="let element" > {{element[column]}} </td>
+    </ng-container>
+  </div>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let element; columns: displayedColumns;"></tr>
+</mat-table>

--- a/frontend/src/app/admin-home/admin-home.component.html
+++ b/frontend/src/app/admin-home/admin-home.component.html
@@ -4,7 +4,7 @@
   <!--Column-->
   <div *ngFor="let column of displayedColumns">
     <ng-container matColumnDef={{column}}>
-      <th mat-header-cell *matHeaderCellDef> {{column}} </th>
+      <th mat-header-cell *matHeaderCellDef> {{ snakeToUpperCase(column) }} </th>
       <td mat-cell *matCellDef="let element" > {{element[column]}} </td>
     </ng-container>
   </div>

--- a/frontend/src/app/admin-home/admin-home.component.spec.ts
+++ b/frontend/src/app/admin-home/admin-home.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminHomeComponent } from './admin-home.component';
+
+describe('AdminHomeComponent', () => {
+  let component: AdminHomeComponent;
+  let fixture: ComponentFixture<AdminHomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AdminHomeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminHomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/admin-home/admin-home.component.ts
+++ b/frontend/src/app/admin-home/admin-home.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../_services/api/api.service';
+import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
+
+@Component({
+  selector: 'app-admin-home',
+  templateUrl: './admin-home.component.html',
+  styleUrls: ['./admin-home.component.scss']
+})
+export class AdminHomeComponent implements OnInit {
+  dataSource: QuestionnaireDataSource;
+  displayedColumns = [];
+
+  constructor(
+    private api: ApiService
+  ) { }
+
+  ngOnInit() {
+    this.dataSource = new QuestionnaireDataSource(this.api);
+    this.dataSource.loadQuestionnaires('identification_questionnaire');
+    this.load_columns();
+  }
+
+  load_columns() {
+    this.api.getQuestionnaireList('identification_questionnaire').subscribe(
+      result => {
+        for (let field in result[0]) {
+          this.displayedColumns.push(field);
+        }
+      }
+    )
+  }
+
+}

--- a/frontend/src/app/admin-home/admin-home.component.ts
+++ b/frontend/src/app/admin-home/admin-home.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../_services/api/api.service';
 
 @Component({
   selector: 'app-admin-home',
@@ -6,18 +7,18 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./admin-home.component.scss']
 })
 export class AdminHomeComponent implements OnInit {
-  questionnaire_names = [
-    'identification_questionnaire',
-    'demographics_questionnaire',
-    'contact_questionnaire',
-    'developmental_questionnaire',
-    'education_self_questionnaire',
-    'education_dependent_questionnaire'
-  ];
+  questionnaire_names = [];
 
-  constructor() { }
+  constructor(
+    private api: ApiService
+  ) { }
 
   ngOnInit() {
+    this.api.getQuestionnaireNames().subscribe(
+      file_names => {
+        this.questionnaire_names = file_names;
+      }
+    )
   }
 
 }

--- a/frontend/src/app/admin-home/admin-home.component.ts
+++ b/frontend/src/app/admin-home/admin-home.component.ts
@@ -31,4 +31,12 @@ export class AdminHomeComponent implements OnInit {
     )
   }
 
+  snakeToUpperCase(s) {
+    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
+      return $1.toUpperCase()
+        .replace('-', ' ')
+        .replace('_', ' ');
+    });
+  }
+
 }

--- a/frontend/src/app/admin-home/admin-home.component.ts
+++ b/frontend/src/app/admin-home/admin-home.component.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { ApiService } from '../_services/api/api.service';
-import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
 
 @Component({
   selector: 'app-admin-home',
@@ -8,35 +6,18 @@ import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
   styleUrls: ['./admin-home.component.scss']
 })
 export class AdminHomeComponent implements OnInit {
-  dataSource: QuestionnaireDataSource;
-  displayedColumns = [];
+  questionnaire_names = [
+    'identification_questionnaire',
+    'demographics_questionnaire',
+    'contact_questionnaire',
+    'developmental_questionnaire',
+    'education_self_questionnaire',
+    'education_dependent_questionnaire'
+  ];
 
-  constructor(
-    private api: ApiService
-  ) { }
+  constructor() { }
 
   ngOnInit() {
-    this.dataSource = new QuestionnaireDataSource(this.api);
-    this.dataSource.loadQuestionnaires('identification_questionnaire');
-    this.load_columns();
-  }
-
-  load_columns() {
-    this.api.getQuestionnaireList('identification_questionnaire').subscribe(
-      result => {
-        for (let field in result[0]) {
-          this.displayedColumns.push(field);
-        }
-      }
-    )
-  }
-
-  snakeToUpperCase(s) {
-    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
-      return $1.toUpperCase()
-        .replace('-', ' ')
-        .replace('_', ' ');
-    });
   }
 
 }

--- a/frontend/src/app/admin-home/admin-home.component.ts
+++ b/frontend/src/app/admin-home/admin-home.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { ApiService } from '../_services/api/api.service';
 
 @Component({
   selector: 'app-admin-home',
@@ -7,18 +6,9 @@ import { ApiService } from '../_services/api/api.service';
   styleUrls: ['./admin-home.component.scss']
 })
 export class AdminHomeComponent implements OnInit {
-  questionnaire_names = [];
 
-  constructor(
-    private api: ApiService
-  ) { }
+  constructor() { }
 
-  ngOnInit() {
-    this.api.getQuestionnaireNames().subscribe(
-      file_names => {
-        this.questionnaire_names = file_names;
-      }
-    )
-  }
+  ngOnInit() { }
 
 }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -50,6 +50,16 @@
       </a>
       <a
         mat-button
+        *ngIf="currentUser && currentUser.role == 'admin'"
+        [routerLink]="[ '/admin' ]"
+        routerLinkActive="selected"
+        id="admin-button"
+      >
+        <mat-icon>build</mat-icon>
+        Admin
+      </a>
+      <a
+        mat-button
         *ngIf="currentUser"
         [routerLink]="[ '/profile' ]"
         routerLinkActive="selected"

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -72,9 +72,10 @@ import { LogoutComponent } from './logout/logout.component';
 import { AvatarDialogComponent } from './avatar-dialog/avatar-dialog.component';
 import { FlowCompleteComponent } from './flow-complete/flow-complete.component';
 import { FlowIntroComponent } from './flow-intro/flow-intro.component';
-import {OverlayContainer} from '@angular/cdk/overlay';
-import {JwtInterceptor} from './_routing/jwt-interceptor';
-import {ErrorInterceptor} from './_routing/error-interceptor';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { JwtInterceptor } from './_routing/jwt-interceptor';
+import { ErrorInterceptor } from './_routing/error-interceptor';
+import { AdminHomeComponent } from './admin-home/admin-home.component';
 
 @Injectable()
 export class FormlyConfig {
@@ -132,7 +133,8 @@ export class FormlyConfig {
     LogoutComponent,
     AvatarDialogComponent,
     FlowCompleteComponent,
-    FlowIntroComponent
+    FlowIntroComponent,
+    AdminHomeComponent
   ],
   imports: [
     BrowserAnimationsModule,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -77,6 +77,7 @@ import { JwtInterceptor } from './_routing/jwt-interceptor';
 import { ErrorInterceptor } from './_routing/error-interceptor';
 import { AdminHomeComponent } from './admin-home/admin-home.component';
 import { QuestionnaireDataTableComponent } from './questionnaire-data-table/questionnaire-data-table.component';
+import { QuestionnaireDataViewComponent } from './questionnaire-data-view/questionnaire-data-view.component';
 
 @Injectable()
 export class FormlyConfig {
@@ -136,7 +137,8 @@ export class FormlyConfig {
     FlowCompleteComponent,
     FlowIntroComponent,
     AdminHomeComponent,
-    QuestionnaireDataTableComponent
+    QuestionnaireDataTableComponent,
+    QuestionnaireDataViewComponent
   ],
   imports: [
     BrowserAnimationsModule,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -76,6 +76,7 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { JwtInterceptor } from './_routing/jwt-interceptor';
 import { ErrorInterceptor } from './_routing/error-interceptor';
 import { AdminHomeComponent } from './admin-home/admin-home.component';
+import { QuestionnaireDataTableComponent } from './questionnaire-data-table/questionnaire-data-table.component';
 
 @Injectable()
 export class FormlyConfig {
@@ -134,7 +135,8 @@ export class FormlyConfig {
     AvatarDialogComponent,
     FlowCompleteComponent,
     FlowIntroComponent,
-    AdminHomeComponent
+    AdminHomeComponent,
+    QuestionnaireDataTableComponent
   ],
   imports: [
     BrowserAnimationsModule,

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.html
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.html
@@ -4,11 +4,11 @@
 >
   <div *ngFor="let column of displayedColumns">
     <!--Column-->
-    <ng-container matColumnDef={{column}}>
-      <th mat-header-cell *matHeaderCellDef> {{ snakeToUpperCase(column) }} </th>
-      <td mat-cell *matCellDef="let element" > {{element[column]}} </td>
+    <ng-container matColumnDef={{column.name}}>
+      <th mat-header-cell *matHeaderCellDef> {{ snakeToUpperCase(column.name) }} </th>
+      <td mat-cell *matCellDef="let element" > {{ format_element(element, column) }}</td>
     </ng-container>
   </div>
-  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let element; columns: displayedColumns;"></tr>
+  <tr mat-header-row *matHeaderRowDef="columnNames"></tr>
+  <tr mat-row *matRowDef="let element; columns: columnNames;"></tr>
 </mat-table>

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.html
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.html
@@ -1,0 +1,14 @@
+<h2>{{ snakeToUpperCase(questionnaire_name) }}</h2>
+<mat-table
+  [dataSource]="dataSource"
+>
+  <div *ngFor="let column of displayedColumns">
+    <!--Column-->
+    <ng-container matColumnDef={{column}}>
+      <th mat-header-cell *matHeaderCellDef> {{ snakeToUpperCase(column) }} </th>
+      <td mat-cell *matCellDef="let element" > {{element[column]}} </td>
+    </ng-container>
+  </div>
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let element; columns: displayedColumns;"></tr>
+</mat-table>

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.scss
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.scss
@@ -1,0 +1,6 @@
+th.mat-header-cell {
+  padding-right: 1em;
+}
+td.mat-cell {
+  padding-right: 1em;
+}

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.spec.ts
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { QuestionnaireDataTableComponent } from './questionnaire-data-table.component';
+
+describe('QuestionnaireDataTableComponent', () => {
+  let component: QuestionnaireDataTableComponent;
+  let fixture: ComponentFixture<QuestionnaireDataTableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ QuestionnaireDataTableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(QuestionnaireDataTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { ApiService } from '../_services/api/api.service';
 import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
+import { snakeToUpperCase } from '../../util/snakeToUpper';
 
 @Component({
   selector: 'app-questionnaire-data-table',
@@ -14,8 +15,9 @@ export class QuestionnaireDataTableComponent implements OnChanges {
   dataSource: QuestionnaireDataSource;
   displayedColumns = [];
 
+
   constructor(
-    private api: ApiService
+    private api: ApiService,
   ) {}
 
   ngOnChanges() {
@@ -37,12 +39,5 @@ export class QuestionnaireDataTableComponent implements OnChanges {
     );
   }
 
-  snakeToUpperCase(s) {
-    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
-      return $1.toUpperCase()
-        .replace('-', ' ')
-        .replace('_', ' ');
-    });
-  }
-
+  get snakeToUpperCase(){ return snakeToUpperCase }
 }

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { ApiService } from '../_services/api/api.service';
+import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
+
+@Component({
+  selector: 'app-questionnaire-data-table',
+  templateUrl: './questionnaire-data-table.component.html',
+  styleUrls: ['./questionnaire-data-table.component.scss']
+})
+export class QuestionnaireDataTableComponent implements OnInit {
+  @Input()
+  questionnaire_name: string;
+
+  dataSource: QuestionnaireDataSource;
+  displayedColumns = [];
+
+  constructor(
+    private api: ApiService
+  ) { }
+
+  ngOnInit() {
+    this.dataSource = new QuestionnaireDataSource(this.api);
+    this.dataSource.loadQuestionnaires(this.questionnaire_name);
+    this.load_columns();
+  }
+
+  load_columns() {
+    this.api.getQuestionnaireList(this.questionnaire_name).subscribe(
+      result => {
+        for (let field in result[0]) {
+          this.displayedColumns.push(field);
+        }
+      }
+    )
+  }
+
+  snakeToUpperCase(s) {
+    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
+      return $1.toUpperCase()
+        .replace('-', ' ')
+        .replace('_', ' ');
+    });
+  }
+
+}

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { ApiService } from '../_services/api/api.service';
 import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
 
@@ -7,7 +7,7 @@ import { QuestionnaireDataSource } from '../_models/questionnaire_data_source';
   templateUrl: './questionnaire-data-table.component.html',
   styleUrls: ['./questionnaire-data-table.component.scss']
 })
-export class QuestionnaireDataTableComponent implements OnInit {
+export class QuestionnaireDataTableComponent implements OnChanges {
   @Input()
   questionnaire_name: string;
 
@@ -16,22 +16,25 @@ export class QuestionnaireDataTableComponent implements OnInit {
 
   constructor(
     private api: ApiService
-  ) { }
+  ) {}
 
-  ngOnInit() {
+  ngOnChanges() {
     this.dataSource = new QuestionnaireDataSource(this.api);
     this.dataSource.loadQuestionnaires(this.questionnaire_name);
     this.load_columns();
   }
 
   load_columns() {
+    this.displayedColumns = [];
     this.api.getQuestionnaireList(this.questionnaire_name).subscribe(
       result => {
         for (let field in result[0]) {
-          this.displayedColumns.push(field);
+          if (!this.displayedColumns.includes(field)){
+            this.displayedColumns.push(field);
+          }
         }
       }
-    )
+    );
   }
 
   snakeToUpperCase(s) {

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
@@ -28,11 +28,11 @@ export class QuestionnaireDataTableComponent implements OnChanges {
 
   load_columns() {
     this.displayedColumns = [];
-    this.api.getQuestionnaireList(this.questionnaire_name).subscribe(
+    this.api.getQuestionnaireListMeta(this.questionnaire_name).subscribe(
       result => {
-        for (let field in result[0]) {
-          if (!this.displayedColumns.includes(field)){
-            this.displayedColumns.push(field);
+        for (let fieldIndex in result['fields']) {
+          if (!this.displayedColumns.includes(result['fields'][fieldIndex].name)){
+            this.displayedColumns.push(result['fields'][fieldIndex].name);
           }
         }
       }

--- a/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
+++ b/frontend/src/app/questionnaire-data-table/questionnaire-data-table.component.ts
@@ -14,6 +14,7 @@ export class QuestionnaireDataTableComponent implements OnChanges {
 
   dataSource: QuestionnaireDataSource;
   displayedColumns = [];
+  columnNames = [];
 
 
   constructor(
@@ -28,15 +29,29 @@ export class QuestionnaireDataTableComponent implements OnChanges {
 
   load_columns() {
     this.displayedColumns = [];
+    this.columnNames = [];
     this.api.getQuestionnaireListMeta(this.questionnaire_name).subscribe(
       result => {
         for (let fieldIndex in result['fields']) {
-          if (!this.displayedColumns.includes(result['fields'][fieldIndex].name)){
-            this.displayedColumns.push(result['fields'][fieldIndex].name);
+          let column = result['fields'][fieldIndex];
+          if (!this.displayedColumns.includes(column.name)){
+            this.displayedColumns.push({'name': column.name, 'type': column.type});
+          }
+          if (!this.columnNames.includes(column.name)){
+            this.columnNames.push(column.name);
           }
         }
       }
     );
+  }
+
+  format_element(element, column) {
+    if (column.type == 'DATETIME') {
+      let date = new Date(element[column.name]);
+      return date.toUTCString();
+    } else {
+      return element[column.name];
+    }
   }
 
   get snakeToUpperCase(){ return snakeToUpperCase }

--- a/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.html
+++ b/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.html
@@ -7,7 +7,7 @@
     </h1>
     <mat-drawer-container>
       <mat-drawer #sidenav
-        [mode]="mobileQuery.matches ? 'over' : 'side'"
+        [mode]='over'
         [(opened)]="sidebarOpen">
           <mat-nav-list *ngFor="let qn of questionnaire_names">
             <mat-list-item

--- a/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.html
+++ b/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.html
@@ -1,0 +1,30 @@
+<div
+  class="mat-typography"
+>
+  <div>
+    <h1>
+      <button mat-icon-button (click)="sidenav.toggle()"><mat-icon>menu</mat-icon></button>
+    </h1>
+    <mat-drawer-container>
+      <mat-drawer #sidenav
+        [mode]="mobileQuery.matches ? 'over' : 'side'"
+        [(opened)]="sidebarOpen">
+          <mat-nav-list *ngFor="let qn of questionnaire_names">
+            <mat-list-item
+              (click)="selectQuestionnaire(qn)"
+            >
+              {{ snakeToUpperCase(qn)}}
+              <span fxFlex></span>
+            </mat-list-item>
+          </mat-nav-list>
+      </mat-drawer>
+      <mat-drawer-content
+        *ngIf="currentQuestionnaire"
+        class="pad-2"
+      >
+        <app-questionnaire-data-table [questionnaire_name]="currentQuestionnaire"></app-questionnaire-data-table>
+      </mat-drawer-content>
+    </mat-drawer-container>
+  </div>
+
+</div>

--- a/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.scss
+++ b/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.scss
@@ -1,0 +1,13 @@
+
+mat-drawer-container {
+  min-height: 100vh;
+  background-color: white;
+}
+
+mat-drawer-content {
+  background-color: white;
+}
+
+.pad-2 {
+  padding: 2em;
+}

--- a/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.spec.ts
+++ b/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { QuestionnaireDataViewComponent } from './questionnaire-data-view.component';
+
+describe('QuestionnaireDataViewComponent', () => {
+  let component: QuestionnaireDataViewComponent;
+  let fixture: ComponentFixture<QuestionnaireDataViewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ QuestionnaireDataViewComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(QuestionnaireDataViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.ts
+++ b/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { MediaMatcher } from '@angular/cdk/layout';
 import { ApiService } from '../_services/api/api.service';
+import { snakeToUpperCase } from '../../util/snakeToUpper';
 
 @Component({
   selector: 'app-questionnaire-data-view',
@@ -40,12 +41,5 @@ export class QuestionnaireDataViewComponent implements OnInit {
     return this.currentQuestionnaire;
   }
 
-  snakeToUpperCase(s) {
-    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
-      return $1.toUpperCase()
-        .replace('-', ' ')
-        .replace('_', ' ');
-    });
-  }
-
+  get snakeToUpperCase(){ return snakeToUpperCase }
 }

--- a/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.ts
+++ b/frontend/src/app/questionnaire-data-view/questionnaire-data-view.component.ts
@@ -1,0 +1,51 @@
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { ApiService } from '../_services/api/api.service';
+
+@Component({
+  selector: 'app-questionnaire-data-view',
+  templateUrl: './questionnaire-data-view.component.html',
+  styleUrls: ['./questionnaire-data-view.component.scss']
+})
+export class QuestionnaireDataViewComponent implements OnInit {
+  questionnaire_names: any;
+  currentQuestionnaire: string;
+
+  mobileQuery: MediaQueryList;
+  private _mobileQueryListener: () => void;
+  sidebarOpen = true;
+
+  constructor(
+    private api: ApiService,
+    changeDetectorRef: ChangeDetectorRef,
+    media: MediaMatcher
+  ) {
+    // We will change the display slightly based on mobile vs desktop
+    this.mobileQuery = media.matchMedia('(max-width: 600px)');
+    this._mobileQueryListener = () => changeDetectorRef.detectChanges();
+    this.mobileQuery.addListener(this._mobileQueryListener);
+  }
+
+  ngOnInit() {
+    this.api.getQuestionnaireNames().subscribe(
+      file_names => {
+        this.questionnaire_names = file_names;
+      }
+    );
+  }
+
+  selectQuestionnaire(qn: string) {
+    this.currentQuestionnaire = qn;
+    this.sidebarOpen = false;
+    return this.currentQuestionnaire;
+  }
+
+  snakeToUpperCase(s) {
+    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
+      return $1.toUpperCase()
+        .replace('-', ' ')
+        .replace('_', ' ');
+    });
+  }
+
+}

--- a/frontend/src/util/snakeToUpper.ts
+++ b/frontend/src/util/snakeToUpper.ts
@@ -1,0 +1,8 @@
+
+  export const snakeToUpperCase = function (s: string) {
+    return s.replace(/([-_][a-z]|^[a-z])/ig, ($1) => {
+      return $1.toUpperCase()
+        .replace('-', ' ')
+        .replace('_', ' ');
+    });
+  };


### PR DESCRIPTION
This is the beginning of an Admin interface, for viewing submitted data from within the app. 
Still needed (among other things):

- [x] Admin security (now any user can view)
- [x] Styling on tables
- [x] Styling in general
- [x] Questionnaires ordered in sidebar
- [x] Fields ordered on tables
- [x] Tests
~~Related table data linked to main tables (Home, Supports, etc)~~

Opening this PR early so that you can see what the data looks like now.
Visit /admin to see the questionnaire data displayed in a series of tables