### PR TITLE
Tracking down some issues with the slave instance and made this minor…

### DIFF
--- a/backend/app/export_service.py
+++ b/backend/app/export_service.py
@@ -2,7 +2,6 @@ import datetime
 import importlib
 import re
 
-from apscheduler.schedulers.background import BackgroundScheduler
 from dateutil.tz import UTC
 from flask import url_for, logging
 from sqlalchemy import func, desc
@@ -26,14 +25,6 @@ class ExportService:
     TYPE_SUB_TABLE = 'sub-table'
 
     DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-
-    @staticmethod
-    def start():
-        scheduler = BackgroundScheduler()
-        scheduler.start()
-        scheduler.add_job(ExportService.send_alert_if_exports_not_running,
-                          'interval',
-                          minutes=app.config['EXPORT_CHECK_INTERNAL_MINUTES'])
 
     @staticmethod
     def get_class_for_table(table):

--- a/backend/app/import_service.py
+++ b/backend/app/import_service.py
@@ -1,7 +1,5 @@
 import datetime
-
 import requests
-from apscheduler.schedulers.background import BackgroundScheduler
 
 # Fire of the scheduler
 # The Data Importer should run on the MIRROR, and will make calls to the primary server to download
@@ -31,12 +29,6 @@ class ImportService:
         self.email = app.config["MASTER_EMAIL"]
         self.password = app.config["MASTER_PASS"]
         self.import_interval_minutes = app.config['IMPORT_INTERVAL_MINUTES']
-
-    def start(self):
-        scheduler = BackgroundScheduler()
-        scheduler.start()
-        scheduler.add_job(self.run_backup, 'interval', minutes=self.import_interval_minutes)
-        scheduler.add_job(self.run_full_backup, 'interval', days=1)
 
     def run_backup(self, load_admin=True, full_backup=False):
         date_started = datetime.datetime.now()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,8 @@ marshmallow==2.15.1
 Flask-Marshmallow==0.7.0
 marshmallow_sqlalchemy==0.13.2
 Flask-Migrate==2.1.1
-psycopg2-binary==2.7.5
+# DO NOT use pyscopg2-binary, it will seg fault in the worst possible way in production.
+psycopg2==2.7.5
 flask-bcrypt==0.7.1
 flask-cors==3.0.3
 flask-httpauth==3.2.4


### PR DESCRIPTION
… changes to the scheudler.

Also had to change the python connector we were using previously.  psycopg2-binary works great in
development but blows up in the most horrible of obfuscated nonsense errors messages in production under apache/wsgi.
 So we need to drop back to using psycopg2 (without -binary).  This will likely require you to install some
system packages to get things reconnected again.  Just do a pip install -r requirements.txt and follow the directions if you get an error.  Was just one apt-get install to get it working again on the server.