### PR TITLE
Feature/topics admin - Fixes #321 - Fixes #337 - Fixes #358 - Fixes #355

### DIFF
--- a/backend/app/model/event.py
+++ b/backend/app/model/event.py
@@ -1,8 +1,3 @@
-import datetime
-
-from dateutil.tz import tzutc
-from sqlalchemy import func
-
 from app import db
 from app.model.location import Location
 

--- a/backend/app/model/role.py
+++ b/backend/app/model/role.py
@@ -14,6 +14,7 @@ class Permission(enum.Enum):
     data_admin = "Visit Data Admin"
     user_detail_admin = "User Admin Data Details"
     export_status = "View Export Status"
+    taxonomy_admin = "Visit Taxonomy Admin"
 
     # keep user_roles and delete_user last to keep off of test user permissions
     delete_user = "Delete User"

--- a/backend/app/resources/CategoryEndpoint.py
+++ b/backend/app/resources/CategoryEndpoint.py
@@ -35,7 +35,7 @@ class CategoryEndpoint(flask_restful.Resource):
         return
 
     def delete_descendants(self, category):
-        if category.children:
+        if category and category.children:
             for cat in category.children:
                 self.delete_descendants(cat)
                 db.session.query(Category).filter_by(id=cat.id).delete()

--- a/backend/app/resources/CategoryEndpoint.py
+++ b/backend/app/resources/CategoryEndpoint.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import joinedload
 
 from app import db, RestException
 from app.model.category import Category
+from app.model.study_category import StudyCategory
+from app.model.resource_category import ResourceCategory
 from app.schema.schema import CategorySchema, ParentCategorySchema
 
 
@@ -18,7 +20,11 @@ class CategoryEndpoint(flask_restful.Resource):
 
     def delete(self, id):
         try:
-            db.session.query(Category).filter(Category.id == id).delete()
+            db.session.query(StudyCategory).filter_by(category_id=id).delete()
+            db.session.query(ResourceCategory).filter_by(category_id=id).delete()
+            db.session.query(Category).filter_by(parent_id=id).delete()
+            db.session.query(Category).filter_by(id=id).delete()
+            db.session.commit()
         except IntegrityError as error:
             raise RestException(RestException.CAN_NOT_DELETE)
         return
@@ -30,6 +36,7 @@ class CategoryEndpoint(flask_restful.Resource):
         if errors:
             raise RestException(RestException.INVALID_OBJECT, details=errors)
         db.session.add(updated)
+        db.session.commit()
         return self.schema.dump(updated)
 
 

--- a/backend/app/resources/StudyEndpoint.py
+++ b/backend/app/resources/StudyEndpoint.py
@@ -7,6 +7,7 @@ from marshmallow import ValidationError
 from app import RestException, db, elastic_index
 from app.model.study import Study
 from app.model.study_category import StudyCategory
+from app.model.study_investigator import StudyInvestigator
 from app.schema.schema import StudySchema
 
 
@@ -25,6 +26,7 @@ class StudyEndpoint(flask_restful.Resource):
         if study is not None:
             elastic_index.remove_document(study, 'Study')
 
+        db.session.query(StudyInvestigator).filter_by(study_id=id).delete()
         db.session.query(StudyCategory).filter_by(study_id=id).delete()
         db.session.query(Study).filter_by(id=id).delete()
         db.session.commit()

--- a/backend/tests/test_category.py
+++ b/backend/tests/test_category.py
@@ -44,16 +44,26 @@ class TestCategory(BaseTest, unittest.TestCase):
         self.assertEqual(response['parent']['name'], 'Strange Kitchen Gadgets')
 
     def test_delete_category(self):
-        c = self.construct_category()
+        self.construct_category(name="Unicorns")
+        self.construct_category(name="Typewriters")
+        c = self.construct_category(name="Pianos")
         c_id = c.id
         rv = self.app.get('api/category/%i' % c_id, content_type="application/json")
         self.assert_success(rv)
+        rv = self.app.get('api/category', content_type="application/json")
+        self.assert_success(rv)
+        response = json.loads(rv.get_data(as_text=True))
+        self.assertEqual(3, len(response))
 
         rv = self.app.delete('api/category/%i' % c_id, content_type="application/json")
         self.assert_success(rv)
 
         rv = self.app.get('api/category/%i' % c_id, content_type="application/json")
         self.assertEqual(404, rv.status_code)
+        rv = self.app.get('api/category', content_type="application/json")
+        self.assert_success(rv)
+        response = json.loads(rv.get_data(as_text=True))
+        self.assertEqual(2, len(response))
 
     def test_create_category(self):
         category = {'name': "My Favorite Things"}

--- a/frontend/e2e/src/admin.e2e-spec.ts
+++ b/frontend/e2e/src/admin.e2e-spec.ts
@@ -50,7 +50,8 @@ describe('Admin', () => {
   it('should navigate to admin screen', () => adminUseCases.navigateToAdmin());
   it('should navigate to user admin tab', () => adminUseCases.navigateToTab(2, '.users-table'));
   it('should navigate to participant admin tab', () => adminUseCases.navigateToTab(3, '.participant-admin'));
-  it('should navigate to import/export status tab', () => adminUseCases.navigateToTab(4, '.logs'));
+  it('should navigate to taxonomy admin tab', () => adminUseCases.navigateToTab(4, '.taxonomy-admin'));
+  it('should navigate to import/export status tab', () => adminUseCases.navigateToTab(5, '.logs'));
   it('should navigate to data admin tab', () => adminUseCases.navigateToTab(1, '.data-list'));
   it('should export all questionnaire data');
   it('should hide sensitive data');

--- a/frontend/src/app/_models/category.ts
+++ b/frontend/src/app/_models/category.ts
@@ -6,6 +6,8 @@ export interface Category {
   parent?: Category;
   level?: number;
   resource_count?: number;
+  event_count?: number;
+  location_count?: number;
   study_count?: number;
   training_count?: number;
   hit_count?: number;

--- a/frontend/src/app/_models/category.ts
+++ b/frontend/src/app/_models/category.ts
@@ -1,5 +1,5 @@
 export interface Category {
-  id: number;
+  id?: number;
   name?: string;
   children?: Category[];
   parent_id?: number;

--- a/frontend/src/app/_routing/role-guard.ts
+++ b/frontend/src/app/_routing/role-guard.ts
@@ -17,7 +17,7 @@ export class RoleGuard implements CanActivate {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    let roles = route.data["roles"] as Array<string>;
+    const roles = route.data['roles'] as Array<string>;
 
     if (!this.currentUser) {
       this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });

--- a/frontend/src/app/_routing/routing.module.ts
+++ b/frontend/src/app/_routing/routing.module.ts
@@ -84,14 +84,14 @@ const routes: Routes = [
   {
     path: 'studies/add',
     component: StudyFormComponent,
-    data: {title: 'Create an Autism DRIVE Study', roles: ['admin',]},
+    data: {title: 'Create an Autism DRIVE Study', roles: ['admin', ]},
     canActivate: [RoleGuard]
   },
   {path: 'study/:studyId', component: StudyDetailComponent, data: {title: 'Study Details'}},
   {
     path: 'study/edit/:studyId',
     component: StudyFormComponent,
-    data: {title: 'Edit Study', roles: ['admin',]},
+    data: {title: 'Edit Study', roles: ['admin', ]},
     canActivate: [RoleGuard]
   },
   {
@@ -106,7 +106,7 @@ const routes: Routes = [
   {
     path: 'admin',
     component: AdminHomeComponent,
-    data: {title: 'Admin Home', roles: ['admin',]},
+    data: {title: 'Admin Home', roles: ['admin', ]},
     canActivate: [RoleGuard]
   },
   {

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -409,12 +409,6 @@ export class ApiService {
       .pipe(catchError(this._handleError));
   }
 
-  /** Update Category */
-  updateCategory(category: Category): Observable<Category> {
-    return this.httpClient.put<Category>(this._endpointUrl('category').replace('<id>', category.id.toString()), category)
-      .pipe(catchError(this._handleError));
-  }
-
   /** Delete Category */
   deleteCategory(category_id: number): Observable<Category> {
     return this.httpClient.delete<Category>(this._endpointUrl('category').replace('<id>', category_id.toString()))

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -403,6 +403,18 @@ export class ApiService {
       .pipe(catchError(this._handleError));
   }
 
+  /** Add Category */
+  addCategory(category: Category): Observable<Category> {
+    return this.httpClient.post<Category>(this._endpointUrl('categoryList'), category)
+      .pipe(catchError(this._handleError));
+  }
+
+  /** Update Category */
+  updateCategory(category: Category): Observable<Category> {
+    return this.httpClient.put<Category>(this._endpointUrl('category').replace('<id>', category.id.toString()), category)
+      .pipe(catchError(this._handleError));
+  }
+
   /** Add Investigator */
   addInvestigator(investigator: Investigator): Observable<Investigator> {
     return this.httpClient.post<Investigator>(this._endpointUrl('investigatorList'), investigator)

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -405,13 +405,19 @@ export class ApiService {
 
   /** Add Category */
   addCategory(category: Category): Observable<Category> {
-    return this.httpClient.post<Category>(this._endpointUrl('categoryList'), category)
+    return this.httpClient.post<Category>(this._endpointUrl('categorylist'), category)
       .pipe(catchError(this._handleError));
   }
 
   /** Update Category */
   updateCategory(category: Category): Observable<Category> {
     return this.httpClient.put<Category>(this._endpointUrl('category').replace('<id>', category.id.toString()), category)
+      .pipe(catchError(this._handleError));
+  }
+
+  /** Delete Category */
+  deleteCategory(category_id: number): Observable<Category> {
+    return this.httpClient.delete<Category>(this._endpointUrl('category').replace('<id>', category_id.toString()))
       .pipe(catchError(this._handleError));
   }
 

--- a/frontend/src/app/admin-home/admin-home.component.html
+++ b/frontend/src/app/admin-home/admin-home.component.html
@@ -4,10 +4,10 @@
   <h1>Administrative Options</h1>
 
   <mat-tab-group>
-    <mat-tab label="Taxonomy Admin"><app-taxonomy-admin></app-taxonomy-admin></mat-tab>
     <mat-tab label="Data Admin"><app-questionnaire-data-view></app-questionnaire-data-view></mat-tab>
     <mat-tab label="User Admin"><app-user-admin></app-user-admin></mat-tab>
     <mat-tab label="Participant Admin"><app-participant-admin></app-participant-admin></mat-tab>
+    <mat-tab label="Taxonomy Admin"><app-taxonomy-admin></app-taxonomy-admin></mat-tab>
     <mat-tab label="Import/Export Status"><app-admin-export></app-admin-export></mat-tab>
   </mat-tab-group>
 

--- a/frontend/src/app/admin-home/admin-home.component.html
+++ b/frontend/src/app/admin-home/admin-home.component.html
@@ -4,6 +4,7 @@
   <h1>Administrative Options</h1>
 
   <mat-tab-group>
+    <mat-tab label="Taxonomy Admin"><app-taxonomy-admin></app-taxonomy-admin></mat-tab>
     <mat-tab label="Data Admin"><app-questionnaire-data-view></app-questionnaire-data-view></mat-tab>
     <mat-tab label="User Admin"><app-user-admin></app-user-admin></mat-tab>
     <mat-tab label="Participant Admin"><app-participant-admin></app-participant-admin></mat-tab>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -128,6 +128,7 @@ import {StudiesComponent} from './studies/studies.component';
 import {StudyDetailComponent} from './study-detail/study-detail.component';
 import {StudyFormComponent} from './study-form/study-form.component';
 import {StudyInquiryComponent} from './study-inquiry/study-inquiry.component';
+import {TaxonomyAdminComponent} from './taxonomy-admin/taxonomy-admin.component';
 import {TermsComponent} from './terms/terms.component';
 import {TimedoutComponent} from './timed-out/timed-out.component';
 import {TypeIconComponent} from './type-icon/type-icon.component';
@@ -277,6 +278,7 @@ export class FormlyConfig {
     ParticipantAdminComponent,
     UvaEducationComponent,
     MultiselectTreeComponent,
+    TaxonomyAdminComponent,
   ],
   imports: [
     AgmCoreModule.forRoot(), // Config provided by ConfService (see providers below)

--- a/frontend/src/app/resource-detail/resource-detail.component.ts
+++ b/frontend/src/app/resource-detail/resource-detail.component.ts
@@ -3,7 +3,6 @@ import {formatDate} from '@angular/common';
 import {Component, OnInit} from '@angular/core';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 import {ActivatedRoute, Router} from '@angular/router';
-import {AdminNote} from '../_models/admin_note';
 import {ContactItem} from '../_models/contact_item';
 import {Resource} from '../_models/resource';
 import {User} from '../_models/user';
@@ -122,7 +121,7 @@ export class ResourceDetailComponent implements OnInit {
       {
         condition: !!r.date,
         icon: 'access_time',
-        details: [r.date && `${formatDate(r.date, 'longDate', 'en-US')}: ${r.time}`]
+        details: [r.date && `${formatDate(r.date, 'longDate', 'en-US', '-0')}: ${r.time}`]
       },
       {
         condition: !!(r.location_name || r.street_address1 || r.street_address2 || r.city || r.state || r.zip),

--- a/frontend/src/app/resource-form/resource-form.component.ts
+++ b/frontend/src/app/resource-form/resource-form.component.ts
@@ -79,6 +79,9 @@ export class ResourceFormComponent implements OnInit {
       templateOptions: {
         label: 'Event Date',
       },
+      expressionProperties: {
+        'templateOptions.required': 'model.type === "event"'
+      },
       hideExpression: 'model.type != "event"',
     },
     {
@@ -87,6 +90,9 @@ export class ResourceFormComponent implements OnInit {
       templateOptions: {
         label: 'Event Time',
         placeholder: 'Please enter the start time or time-frame for your event',
+      },
+      expressionProperties: {
+        'templateOptions.required': 'model.type === "event"'
       },
       hideExpression: 'model.type != "event"',
     },
@@ -228,6 +234,7 @@ export class ResourceFormComponent implements OnInit {
       type: 'multiselecttree',
       templateOptions: {
         label: 'Topics',
+        description: 'This field is required',
         options: this.api.getCategoryTree(),
         valueProp: 'id',
         labelProp: 'name',
@@ -380,11 +387,23 @@ export class ResourceFormComponent implements OnInit {
   }
 
   updateAndClose(apiCall) {
+    this.setDateTime();
     apiCall.subscribe(r => {
       this.updatedResource = r;
       this.model.id = r.id;
       this.updateResourceCategories(r.id).subscribe(() => this.close());
     });
+  }
+
+  setDateTime() {
+    if (this.model.date) {
+      if (this.model.date instanceof Date) {
+          this.model.date.setHours(12);
+      } else {
+        this.model.date = new Date(this.model.date);
+        this.model.date.setHours(12);
+      }
+    }
   }
 
   showDelete() {

--- a/frontend/src/app/resource-form/resource-form.component.ts
+++ b/frontend/src/app/resource-form/resource-form.component.ts
@@ -371,6 +371,7 @@ export class ResourceFormComponent implements OnInit {
 
     if (this.form.valid) {
       if (this.createNew) {
+        this.createNew = false;
         this.updateOrganization(() => this.updateAndClose(this.api[`add${resourceType}`](this.model)));
       } else {
         this.updateOrganization(() => this.updateAndClose(this.api[`update${resourceType}`](this.model)));

--- a/frontend/src/app/resource-form/resource-form.component.ts
+++ b/frontend/src/app/resource-form/resource-form.component.ts
@@ -382,6 +382,7 @@ export class ResourceFormComponent implements OnInit {
   updateAndClose(apiCall) {
     apiCall.subscribe(r => {
       this.updatedResource = r;
+      this.model.id = r.id;
       this.updateResourceCategories(r.id).subscribe(() => this.close());
     });
   }

--- a/frontend/src/app/studies/studies.component.ts
+++ b/frontend/src/app/studies/studies.component.ts
@@ -40,8 +40,8 @@ export class StudiesComponent implements OnInit {
 
   loadStudies() {
     this.api.getStudies().subscribe(studies => {
-      this.studyHits = this._studiesToHits(studies.filter(s => s.status === this.selectedStatus.name))
-    })
+      this.studyHits = this._studiesToHits(studies.filter(s => s.status === this.selectedStatus.name));
+    });
   }
 
   selectStatus(status: StudyStatusObj) {

--- a/frontend/src/app/study-form/study-form.component.ts
+++ b/frontend/src/app/study-form/study-form.component.ts
@@ -408,6 +408,7 @@ export class StudyFormComponent implements OnInit {
     // Post to the study endpoint, and then close
     if (this.form.valid) {
       if (this.createNew) {
+        this.createNew = false;
         this.updateOrganization(() => this.updateAndClose(this.api.addStudy(this.model)));
       } else {
         this.updateOrganization(() => this.updateAndClose(this.api.updateStudy(this.model)));
@@ -418,6 +419,7 @@ export class StudyFormComponent implements OnInit {
   updateAndClose(apiCall) {
     apiCall.subscribe(s => {
       this.updatedStudy = s;
+      this.model.id = s.id;
       if (this.model.additional_investigators.name) {
         this.addStudyInvestigator().subscribe((i) => {
           this.model.investigators.push(i.id);

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -1,4 +1,6 @@
 <h1>Topics Taxonomy</h1>
+<p>To add a topic, click the plus sign next to the parent topic and fill in the name</p>
+<p>To delete topics, select the check boxes next to the ones you wish to delete and click the delete button</p>
 <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select">
   <!-- Child node-->
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
@@ -6,7 +8,7 @@
       <!-- use a disabled button to provide padding for tree leaf -->
       <button disabled mat-icon-button></button>
       <mat-checkbox (change)="toggleNode(node)" [checked]="checklistSelection.isSelected(node)"
-                    [indeterminate]="descendantsPartiallySelected(node)">{{node.name}}</mat-checkbox>
+                    >{{node.name}}</mat-checkbox>
     </li>
   </mat-tree-node>
 
@@ -36,9 +38,8 @@
         </button>
 
         <mat-checkbox
-          (change)="toggleParentNode(node)"
+          (change)="toggleNode(node)"
           [checked]="checklistSelection.isSelected(node)"
-          [indeterminate]="descendantsPartiallySelected(node)"
         >
             <span
               *ngIf="numSelectedDescendants(node)"
@@ -56,3 +57,28 @@
     </li>
   </mat-nested-tree-node>
 </mat-tree>
+
+<div
+  class="button-row"
+  fxLayout="row"
+  fxLayoutGap="2em"
+>
+  <button
+    type="button"
+    mat-flat-button
+    *ngIf="!showConfirmDelete"
+    (click)="showDelete()"
+    color="warn"
+    id="delete-button"
+  >Delete Selected Topics</button>
+
+  <button
+    *ngIf="showConfirmDelete"
+    id="confirm_delete"
+    type="button"
+    mat-flat-button
+    (click)="onDelete()"
+    color="warn"
+  >Permanently Delete Selected Topics!!!
+  </button>
+</div>

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -1,7 +1,7 @@
 <h1>Topics Taxonomy</h1>
 <p>To add a topic, click the plus sign next to the parent topic and fill in the name</p>
 <p>To delete topics, select the check boxes next to the ones you wish to delete and click the delete button</p>
-<mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select">
+<mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select taxonomy-admin">
   <!-- Child node-->
   <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
     <li class="mat-tree-node">

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -1,0 +1,58 @@
+<h1>Topics Taxonomy</h1>
+<mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select">
+  <!-- Child node-->
+  <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+    <li class="mat-tree-node">
+      <!-- use a disabled button to provide padding for tree leaf -->
+      <button disabled mat-icon-button></button>
+      <mat-checkbox (change)="toggleNode(node)" [checked]="checklistSelection.isSelected(node)"
+                    [indeterminate]="descendantsPartiallySelected(node)">{{node.name}}</mat-checkbox>
+    </li>
+  </mat-tree-node>
+
+  <!--New Item Node-->
+  <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
+    <button mat-icon-button disabled></button>
+    <mat-form-field>
+      <mat-label>New item...</mat-label>
+      <input matInput #itemValue placeholder="Ex. Lettuce">
+    </mat-form-field>
+    <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
+  </mat-tree-node>
+
+  <!-- Parent node -->
+  <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
+    <li>
+      <div class="mat-tree-node">
+        <button
+          [attr.aria-label]="'toggle ' + node.name"
+          class="toggle-node-button"
+          mat-icon-button
+          matTreeNodeToggle
+        >
+          <mat-icon class="mat-icon-rtl-mirror">
+            {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+          </mat-icon>
+        </button>
+
+        <mat-checkbox
+          (change)="toggleParentNode(node)"
+          [checked]="checklistSelection.isSelected(node)"
+          [indeterminate]="descendantsPartiallySelected(node)"
+        >
+            <span
+              *ngIf="numSelectedDescendants(node)"
+              matBadge="{{numSelectedDescendants(node)}}"
+              matBadgeColor="accent"
+              matBadgeOverlap="false"
+            >{{node.name}}</span>
+          <span *ngIf="!numSelectedDescendants(node)">{{node.name}}</span>
+        </mat-checkbox>
+        <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
+      </div>
+      <ul [class.tree-select-invisible]="!treeControl.isExpanded(node)">
+        <ng-container matTreeNodeOutlet></ng-container>
+      </ul>
+    </li>
+  </mat-nested-tree-node>
+</mat-tree>

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -8,8 +8,11 @@
       <li class="mat-tree-node">
         <!-- use a disabled button to provide padding for tree leaf -->
         <button disabled mat-icon-button></button>
-        <mat-checkbox (change)="toggleNode(node)" [checked]="checklistSelection.isSelected(node)"
-                      >{{node.name}}</mat-checkbox>
+        <mat-checkbox
+          (change)="toggleNode(node)"
+          [checked]="checklistSelection.isSelected(node)"
+        >{{node.name}}</mat-checkbox>
+        <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
       </li>
     </mat-tree-node>
 

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -1,84 +1,86 @@
-<h1>Topics Taxonomy</h1>
-<p>To add a topic, click the plus sign next to the parent topic and fill in the name</p>
-<p>To delete topics, select the check boxes next to the ones you wish to delete and click the delete button</p>
-<mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select taxonomy-admin">
-  <!-- Child node-->
-  <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-    <li class="mat-tree-node">
-      <!-- use a disabled button to provide padding for tree leaf -->
-      <button disabled mat-icon-button></button>
-      <mat-checkbox (change)="toggleNode(node)" [checked]="checklistSelection.isSelected(node)"
-                    >{{node.name}}</mat-checkbox>
-    </li>
-  </mat-tree-node>
+<div *ngIf="currentUser && currentUser.permissions.includes('publish_resource')">
+  <h1>Topics Taxonomy</h1>
+  <p>To add a topic, click the plus sign next to the parent topic and fill in the name</p>
+  <p>To delete topics, select the check boxes next to the ones you wish to delete and click the delete button</p>
+  <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select taxonomy-admin">
+    <!-- Child node-->
+    <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+      <li class="mat-tree-node">
+        <!-- use a disabled button to provide padding for tree leaf -->
+        <button disabled mat-icon-button></button>
+        <mat-checkbox (change)="toggleNode(node)" [checked]="checklistSelection.isSelected(node)"
+                      >{{node.name}}</mat-checkbox>
+      </li>
+    </mat-tree-node>
 
-  <!--New Item Node-->
-  <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
-    <button mat-icon-button disabled></button>
-    <mat-form-field>
-      <mat-label>New item...</mat-label>
-      <input matInput #itemValue placeholder="Ex. Lettuce">
-    </mat-form-field>
-    <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
-  </mat-tree-node>
+    <!--New Item Node-->
+    <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
+      <button mat-icon-button disabled></button>
+      <mat-form-field>
+        <mat-label>New item...</mat-label>
+        <input matInput #itemValue placeholder="Ex. Lettuce">
+      </mat-form-field>
+      <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
+    </mat-tree-node>
 
-  <!-- Parent node -->
-  <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
-    <li>
-      <div class="mat-tree-node">
-        <button
-          [attr.aria-label]="'toggle ' + node.name"
-          class="toggle-node-button"
-          mat-icon-button
-          matTreeNodeToggle
-        >
-          <mat-icon class="mat-icon-rtl-mirror">
-            {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
-          </mat-icon>
-        </button>
+    <!-- Parent node -->
+    <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
+      <li>
+        <div class="mat-tree-node">
+          <button
+            [attr.aria-label]="'toggle ' + node.name"
+            class="toggle-node-button"
+            mat-icon-button
+            matTreeNodeToggle
+          >
+            <mat-icon class="mat-icon-rtl-mirror">
+              {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+            </mat-icon>
+          </button>
 
-        <mat-checkbox
-          (change)="toggleNode(node)"
-          [checked]="checklistSelection.isSelected(node)"
-        >
-            <span
-              *ngIf="numSelectedDescendants(node)"
-              matBadge="{{numSelectedDescendants(node)}}"
-              matBadgeColor="accent"
-              matBadgeOverlap="false"
-            >{{node.name}}</span>
-          <span *ngIf="!numSelectedDescendants(node)">{{node.name}}</span>
-        </mat-checkbox>
-        <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
-      </div>
-      <ul [class.tree-select-invisible]="!treeControl.isExpanded(node)">
-        <ng-container matTreeNodeOutlet></ng-container>
-      </ul>
-    </li>
-  </mat-nested-tree-node>
-</mat-tree>
+          <mat-checkbox
+            (change)="toggleNode(node)"
+            [checked]="checklistSelection.isSelected(node)"
+          >
+              <span
+                *ngIf="numSelectedDescendants(node)"
+                matBadge="{{numSelectedDescendants(node)}}"
+                matBadgeColor="accent"
+                matBadgeOverlap="false"
+              >{{node.name}}</span>
+            <span *ngIf="!numSelectedDescendants(node)">{{node.name}}</span>
+          </mat-checkbox>
+          <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
+        </div>
+        <ul [class.tree-select-invisible]="!treeControl.isExpanded(node)">
+          <ng-container matTreeNodeOutlet></ng-container>
+        </ul>
+      </li>
+    </mat-nested-tree-node>
+  </mat-tree>
 
-<div
-  class="button-row"
-  fxLayout="row"
-  fxLayoutGap="2em"
->
-  <button
-    type="button"
-    mat-flat-button
-    *ngIf="!showConfirmDelete"
-    (click)="showDelete()"
-    color="warn"
-    id="delete-button"
-  >Delete Selected Topics</button>
+  <div
+    class="button-row"
+    fxLayout="row"
+    fxLayoutGap="2em"
+  >
+    <button
+      type="button"
+      mat-flat-button
+      *ngIf="!showConfirmDelete"
+      (click)="showDelete()"
+      color="warn"
+      id="delete-button"
+    >Delete Selected Topics</button>
 
-  <button
-    *ngIf="showConfirmDelete"
-    id="confirm_delete"
-    type="button"
-    mat-flat-button
-    (click)="onDelete()"
-    color="warn"
-  >Permanently Delete Selected Topics!!!
-  </button>
+    <button
+      *ngIf="showConfirmDelete"
+      id="confirm_delete"
+      type="button"
+      mat-flat-button
+      (click)="onDelete()"
+      color="warn"
+    >Permanently Delete Selected Topics!!!
+    </button>
+  </div>
 </div>

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -11,7 +11,7 @@
         <mat-checkbox
           (change)="toggleNode(node)"
           [checked]="checklistSelection.isSelected(node)"
-        >{{node.name}}</mat-checkbox>
+        >{{node.name}} ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</mat-checkbox>
         <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
       </li>
     </mat-tree-node>
@@ -50,8 +50,8 @@
                 matBadge="{{numSelectedDescendants(node)}}"
                 matBadgeColor="accent"
                 matBadgeOverlap="false"
-              >{{node.name}}</span>
-            <span *ngIf="!numSelectedDescendants(node)">{{node.name}}</span>
+              >{{node.name}} ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</span>
+            <span *ngIf="!numSelectedDescendants(node)">{{node.name}} ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</span>
           </mat-checkbox>
           <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
         </div>

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.scss
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.scss
@@ -1,0 +1,15 @@
+.tree-select-invisible {
+  display: none;
+}
+
+.tree-select ul,
+.tree-select li {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 1rem;
+  list-style-type: none;
+
+  button.toggle-node-button {
+    outline: none !important;
+  }
+}

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.spec.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaxonomyAdminComponent } from './taxonomy-admin.component';
+
+describe('TaxonomyAdminComponent', () => {
+  let component: TaxonomyAdminComponent;
+  let fixture: ComponentFixture<TaxonomyAdminComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TaxonomyAdminComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TaxonomyAdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -5,6 +5,8 @@ import {MatTreeNestedDataSource} from '@angular/material/tree';
 import {of} from 'rxjs';
 import {Category} from '../_models/category';
 import {ApiService} from '../_services/api/api.service';
+import {User} from '../_models/user';
+import {AuthenticationService} from '../_services/api/authentication-service';
 
 @Component({
   selector: 'app-taxonomy-admin',
@@ -18,15 +20,18 @@ export class TaxonomyAdminComponent implements OnInit {
   dataLoaded = false;
   nodes = {};
   showConfirmDelete = false;
+  currentUser: User;
 
   /** The selection for checklist */
   checklistSelection = new SelectionModel<Category>(true /* multiple */);
 
   constructor(
-    private api: ApiService
+    private api: ApiService,
+    private authenticationService: AuthenticationService,
   ) {
     this.treeControl = new NestedTreeControl<Category>(node => of(node.children));
     this.dataSource = new MatTreeNestedDataSource();
+    this.authenticationService.currentUser.subscribe(x => this.currentUser = x);
     this.getCategoryTree();
   }
 

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -98,6 +98,7 @@ export class TaxonomyAdminComponent implements OnInit {
           this.treeControl.collapseAll();
           this.getCategoryTree();
           window.scroll(0, 0);
+          this.showConfirmDelete = false;
         }
       });
     });

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -27,10 +27,10 @@ export class TaxonomyAdminComponent implements OnInit {
   ) {
     this.treeControl = new NestedTreeControl<Category>(node => of(node.children));
     this.dataSource = new MatTreeNestedDataSource();
+    this.getCategoryTree();
   }
 
   ngOnInit() {
-    this.getCategoryTree();
   }
 
   getCategoryTree() {
@@ -74,24 +74,28 @@ export class TaxonomyAdminComponent implements OnInit {
   saveNode(node: Category, itemValue: string) {
     node.name = itemValue;
     this.api.addCategory(node).subscribe(cat => {
+      this.treeControl.collapseAll();
       this.getCategoryTree();
       window.scroll(0, 0);
     });
   }
-
 
   showDelete() {
     this.showConfirmDelete = true;
   }
 
   onDelete() {
-    this.checklistSelection.selected.forEach(cat => {
-      console.log('cat', cat);
-      this.api.deleteCategory(cat.id).subscribe();
+    let itemsProcessed = 0;
+    this.checklistSelection.selected.forEach((cat, index, array) => {
+      this.api.deleteCategory(cat.id).subscribe(cat => {
+        itemsProcessed++;
+        if (itemsProcessed === array.length) {
+          this.treeControl.collapseAll();
+          this.getCategoryTree();
+          window.scroll(0, 0);
+        }
+      });
     });
-
-    this.getCategoryTree();
-    window.scroll(0, 0);
   }
 
 }

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -43,26 +43,13 @@ export class TaxonomyAdminComponent implements OnInit {
     return (node.children && (node.children.length > 0));
   };
 
-  /** Whether all the descendants of the node are selected */
-  descendantsAllSelected(node: Category): boolean {
-    const descendants = this.treeControl.getDescendants(node);
-    return descendants.every(child => this.checklistSelection.isSelected(child));
-  }
-
-  /** Whether part of the descendants are selected */
-  descendantsPartiallySelected(node: Category): boolean {
-    const descendants = this.treeControl.getDescendants(node);
-    const result = descendants.some(child => this.checklistSelection.isSelected(child));
-    return result && !this.descendantsAllSelected(node);
-  }
-
   numSelectedDescendants(node: Category): number {
     const descendants: Category[] = this.treeControl.getDescendants(node);
     const selectedDescendants = descendants.filter(d => this.checklistSelection.isSelected(d));
     return selectedDescendants.length;
   }
 
-  /** Toggle the to-do item selection. Select/deselect all the descendants node */
+  /** Toggle the category item selection. Select/deselect all the descendants node */
   toggleNode(node: Category): void {
     this.checklistSelection.toggle(node);
     const descendants = this.treeControl.getDescendants(node);

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -1,0 +1,147 @@
+import {SelectionModel} from '@angular/cdk/collections';
+import {NestedTreeControl} from '@angular/cdk/tree';
+import {Component, OnInit} from '@angular/core';
+import {MatTreeNestedDataSource} from '@angular/material/tree';
+import {Observable, of} from 'rxjs';
+import {Category} from '../_models/category';
+import {ApiService} from '../_services/api/api.service';
+
+@Component({
+  selector: 'app-taxonomy-admin',
+  templateUrl: './taxonomy-admin.component.html',
+  styleUrls: ['./taxonomy-admin.component.scss']
+})
+export class TaxonomyAdminComponent implements OnInit {
+  categories: Category[] = [];
+  treeControl: NestedTreeControl<Category>;
+  dataSource: MatTreeNestedDataSource<Category>;
+  dataLoaded = false;
+  nodes = {};
+
+  /** The selection for checklist */
+  checklistSelection = new SelectionModel<Category>(true /* multiple */);
+
+  constructor(
+    private api: ApiService
+  ) {
+    this.treeControl = new NestedTreeControl<Category>(node => of(node.children));
+    this.dataSource = new MatTreeNestedDataSource();
+  }
+
+  ngOnInit() {
+    this.api.getCategoryTree().subscribe((categories: Category[]) => {
+      this.dataSource.data = categories;
+      this.categories = categories;
+      this.updateSelection();
+    });
+  }
+
+  updateSelection() {
+    // if (this.isReady()) {
+      // if (this.model.categories) {
+      //   this.model.categories.forEach(cat => {
+      //     const node = this.findNode(cat);
+      //     if (node) {
+      //       this.checklistSelection.toggle(node);
+      //     }
+      //     this._updateModelCategories();
+      //   });
+      // }
+      this.dataLoaded = true;
+    // }
+  }
+
+  findNode(cat: Category) {
+    const allNodes = [];
+
+    this.dataSource.data.forEach(dataCat => {
+      const descendants = this.treeControl.getDescendants(dataCat);
+      descendants.forEach(d => allNodes.push(d));
+      allNodes.push(dataCat);
+
+    });
+    return allNodes.find(i => i.id === cat.id);
+  }
+
+  hasNestedChild = (_: number, node: Category) => {
+    return (node.children && (node.children.length > 0));
+  }
+
+  /** Whether all the descendants of the node are selected */
+  descendantsAllSelected(node: Category): boolean {
+    const descendants = this.treeControl.getDescendants(node);
+    return descendants.every(child => this.checklistSelection.isSelected(child));
+  }
+
+  /** Whether part of the descendants are selected */
+  descendantsPartiallySelected(node: Category): boolean {
+    const descendants = this.treeControl.getDescendants(node);
+    const result = descendants.some(child => this.checklistSelection.isSelected(child));
+    return result && !this.descendantsAllSelected(node);
+  }
+
+  numSelectedDescendants(node: Category): number {
+    const descendants: Category[] = this.treeControl.getDescendants(node);
+    const selectedDescendants = descendants.filter(d => this.checklistSelection.isSelected(d));
+    return selectedDescendants.length;
+  }
+
+  /** Toggle the to-do item selection. Select/deselect all the descendants node */
+  toggleNode(node: Category): void {
+    this.checklistSelection.toggle(node);
+    const descendants = this.treeControl.getDescendants(node);
+    this.checklistSelection.isSelected(node)
+      ? this.checklistSelection.select(...descendants)
+      : this.checklistSelection.deselect(...descendants);
+
+    this._updateModelCategories();
+  }
+
+  // isReady(): boolean {
+  //   return !!(
+  //     this.field &&
+  //     this.field.form &&
+  //     this.field.form.controls
+  //   );
+  // }
+
+  /** Toggle the to-do item selection. Select/deselect all the descendants node */
+  toggleParentNode(node: Category): void {
+    this.checklistSelection.toggle(node);
+    const descendants = this.treeControl.getDescendants(node);
+    this.checklistSelection.isSelected(node)
+      ? this.checklistSelection.select(...descendants)
+      : this.checklistSelection.deselect(...descendants);
+
+    // Force update for the parent
+    descendants.every(child =>
+      this.checklistSelection.isSelected(child)
+    );
+
+    this._updateModelCategories();
+  }
+
+  private _updateModelCategories() {
+    // this.model.categories = [];
+    // this.checklistSelection.selected.forEach(c => this.model.categories[c.id] = true);
+  }
+
+  hasNoContent = (_: number, _nodeData: Category) => _nodeData.name === '';
+
+  /** Select the category so we can insert the new item. */
+  addNewItem(node: Category) {
+    this.api.addCategory({'name': '', 'parent': node}).subscribe();
+    // const data = this.dataSource.data;
+    // data.push({'name': '', 'parent': node});
+    // this.dataSource.data = data;
+    this.treeControl.expand(node);
+  }
+
+  /** Save the node to database */
+  saveNode(node: Category, itemValue: string) {
+    // const nestedNode = this.flatNodeMap.get(node);
+    // this._database.updateItem(nestedNode!, itemValue);
+    node.name = itemValue;
+    this.api.updateCategory(node).subscribe();
+  }
+}

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -46,7 +46,7 @@ export class TaxonomyAdminComponent implements OnInit {
 
   hasNestedChild = (_: number, node: Category) => {
     return (node.children && (node.children.length > 0));
-  };
+  }
 
   numSelectedDescendants(node: Category): number {
     const descendants: Category[] = this.treeControl.getDescendants(node);
@@ -92,7 +92,7 @@ export class TaxonomyAdminComponent implements OnInit {
   onDelete() {
     let itemsProcessed = 0;
     this.checklistSelection.selected.forEach((cat, index, array) => {
-      this.api.deleteCategory(cat.id).subscribe(cat => {
+      this.api.deleteCategory(cat.id).subscribe(c => {
         itemsProcessed++;
         if (itemsProcessed === array.length) {
           this.treeControl.collapseAll();

--- a/frontend/src/util/scrollToTop.ts
+++ b/frontend/src/util/scrollToTop.ts
@@ -17,9 +17,9 @@ export const scrollToFirstInvalidField = function (deviceDetectorService: Device
   const el: HTMLElement = document.querySelector('mat-form-field.ng-invalid');
   if (el) {
     if (deviceDetectorService.browser === 'Safari') {
-      window.scroll(0, el.offsetTop-200);
+      window.scroll(0, el.offsetTop - 200);
     } else {
-      window.scroll({behavior: 'smooth', top: el.offsetTop-200});
+      window.scroll({behavior: 'smooth', top: el.offsetTop - 200});
     }
   }
 };


### PR DESCRIPTION
The main feature in this PR is the addition of a Topics Taxonomy Admin page. This page lives within the Admin menu tabs and allows admin users to add and delete topics within the context of the existing taxonomy. 

Additional fixes include the event date bug, the study delete bug, and the bug where multiple resources/studies would be created when the form save button got into a strange state.