### PR TITLE
Bug/topics

### DIFF
--- a/backend/app/resources/CategoryEndpoint.py
+++ b/backend/app/resources/CategoryEndpoint.py
@@ -24,8 +24,6 @@ class CategoryEndpoint(flask_restful.Resource):
     @requires_permission(Permission.taxonomy_admin)
     def delete(self, id):
         try:
-            cat = db.session.query(Category).filter_by(id=id).first()
-            self.delete_descendants(cat)
             db.session.query(StudyCategory).filter_by(category_id=id).delete()
             db.session.query(ResourceCategory).filter_by(category_id=id).delete()
             db.session.query(Category).filter_by(id=id).delete()
@@ -33,12 +31,6 @@ class CategoryEndpoint(flask_restful.Resource):
         except IntegrityError as error:
             raise RestException(RestException.CAN_NOT_DELETE)
         return
-
-    def delete_descendants(self, category):
-        if category and category.children:
-            for cat in category.children:
-                self.delete_descendants(cat)
-                db.session.query(Category).filter_by(id=cat.id).delete()
 
     @auth.login_required
     @requires_permission(Permission.taxonomy_admin)

--- a/backend/app/resources/EventAndCategoryEndpoint.py
+++ b/backend/app/resources/EventAndCategoryEndpoint.py
@@ -1,7 +1,7 @@
 import flask_restful
 from flask import request
 
-from app import db, RestException
+from app import db, RestException, elastic_index
 from app.model.category import Category
 from app.model.event import Event
 from app.model.resource_category import ResourceCategory
@@ -41,6 +41,8 @@ class CategoryByEventEndpoint(flask_restful.Resource):
             db.session.add(ResourceCategory(resource_id=event_id,
                            category_id=c.category_id, type='event'))
         db.session.commit()
+        instance = db.session.query(Event).filter_by(id=event_id).first()
+        elastic_index.update_document(instance, 'Event', latitude=instance.latitude, longitude=instance.longitude)
         return self.get(event_id)
 
 

--- a/backend/app/resources/LocationAndCategoryEndpoint.py
+++ b/backend/app/resources/LocationAndCategoryEndpoint.py
@@ -1,7 +1,7 @@
 import flask_restful
 from flask import request
 
-from app import db, RestException
+from app import db, RestException, elastic_index
 from app.model.category import Category
 from app.model.location import Location
 from app.model.resource_category import ResourceCategory
@@ -41,6 +41,8 @@ class CategoryByLocationEndpoint(flask_restful.Resource):
             db.session.add(ResourceCategory(resource_id=location_id,
                            category_id=c.category_id, type='location'))
         db.session.commit()
+        instance = db.session.query(Location).filter_by(id=location_id).first()
+        elastic_index.update_document(instance, 'Location', latitude=instance.latitude, longitude=instance.longitude)
         return self.get(location_id)
 
 

--- a/backend/app/resources/ResourceAndCategoryEndpoint.py
+++ b/backend/app/resources/ResourceAndCategoryEndpoint.py
@@ -39,7 +39,7 @@ class CategoryByResourceEndpoint(flask_restful.Resource):
         db.session.query(ResourceCategory).filter_by(resource_id=resource_id).delete()
         for c in resource_categories:
             db.session.add(ResourceCategory(resource_id=resource_id,
-                           category_id=c.category_id))
+                           category_id=c.category_id, type='resource'))
         db.session.commit()
         instance = db.session.query(Resource).filter_by(id=resource_id).first()
         elastic_index.update_document(instance, 'Resource')

--- a/backend/app/resources/ResourceAndCategoryEndpoint.py
+++ b/backend/app/resources/ResourceAndCategoryEndpoint.py
@@ -1,7 +1,7 @@
 import flask_restful
 from flask import request
 
-from app import db, RestException
+from app import db, RestException, elastic_index
 from app.model.category import Category
 from app.model.resource import Resource
 from app.model.resource_category import ResourceCategory
@@ -41,6 +41,8 @@ class CategoryByResourceEndpoint(flask_restful.Resource):
             db.session.add(ResourceCategory(resource_id=resource_id,
                            category_id=c.category_id))
         db.session.commit()
+        instance = db.session.query(Resource).filter_by(id=resource_id).first()
+        elastic_index.update_document(instance, 'Resource')
         return self.get(resource_id)
 
 

--- a/backend/tests/test_category.py
+++ b/backend/tests/test_category.py
@@ -68,7 +68,7 @@ class TestCategory(BaseTest, unittest.TestCase):
         response = json.loads(rv.get_data(as_text=True))
         self.assertEqual(2, len(response))
 
-    def test_delete_category_deletes_descendants(self):
+    def test_delete_category_will_not_delete_descendants(self):
         wool = self.construct_category(name='wool')
         yarn = self.construct_category(name='yarn', parent=wool)
         self.construct_category(name='roving', parent=wool)
@@ -89,12 +89,11 @@ class TestCategory(BaseTest, unittest.TestCase):
         rv = self.app.delete('api/category/%i' % wool.id,
                              content_type="application/json",
                              headers=self.logged_in_headers())
-        self.assert_success(rv)
-
-        rv = self.app.get('api/category', content_type="application/json")
-        self.assert_success(rv)
+        self.assertEqual(400, rv.status_code)
         response = json.loads(rv.get_data(as_text=True))
-        self.assertEqual(0, len(response))
+        self.assertIsNotNone(response)
+        self.assertEqual("can_not_delete", response["code"])
+        self.assertEqual("You must delete all dependent records first.", response["message"])
 
     def test_create_category(self):
         category = {'name': "My Favorite Things"}

--- a/frontend/e2e/protractor.conf.js
+++ b/frontend/e2e/protractor.conf.js
@@ -24,7 +24,7 @@ exports.config = {
   },
   onPrepare() {
     require('ts-node').register({
-      project: 'e2e/tsconfig.e2e.json'
+      project: 'tsconfig.e2e.json'
     });
     jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
   }

--- a/frontend/src/app/_forms/multiselect-tree/multiselect-tree.component.html
+++ b/frontend/src/app/_forms/multiselect-tree/multiselect-tree.component.html
@@ -4,8 +4,10 @@
     <li class="mat-tree-node">
       <!-- use a disabled button to provide padding for tree leaf -->
       <button disabled mat-icon-button></button>
-      <mat-checkbox (change)="toggleNode(node)" [checked]="checklistSelection.isSelected(node)"
-                    [indeterminate]="descendantsPartiallySelected(node)">{{node.name}}</mat-checkbox>
+      <mat-checkbox
+        (change)="toggleNode(node)"
+        [checked]="checklistSelection.isSelected(node)"
+      >{{node.name}}</mat-checkbox>
     </li>
   </mat-tree-node>
 
@@ -25,16 +27,15 @@
         </button>
 
         <mat-checkbox
-          (change)="toggleParentNode(node)"
+          disabled="true"
           [checked]="checklistSelection.isSelected(node)"
-          [indeterminate]="descendantsPartiallySelected(node)"
         >
-            <span
-              *ngIf="numSelectedDescendants(node)"
-              matBadge="{{numSelectedDescendants(node)}}"
-              matBadgeColor="accent"
-              matBadgeOverlap="false"
-            >{{node.name}}</span>
+          <span
+            *ngIf="numSelectedDescendants(node)"
+            matBadge="{{numSelectedDescendants(node)}}"
+            matBadgeColor="accent"
+            matBadgeOverlap="false"
+          >{{node.name}}</span>
           <span *ngIf="!numSelectedDescendants(node)">{{node.name}}</span>
         </mat-checkbox>
       </div>

--- a/frontend/src/app/_forms/multiselect-tree/multiselect-tree.component.ts
+++ b/frontend/src/app/_forms/multiselect-tree/multiselect-tree.component.ts
@@ -76,25 +76,25 @@ export class MultiselectTreeComponent extends FieldType implements OnInit {
   /** Toggle the category item selection. Select/deselect all the parent/grandparent nodes */
   toggleNode(node: Category): void {
     this.checklistSelection.toggle(node);
-    let ancestors = [];
+    const ancestors = [];
     let parent = this.findNode(node.parent_id);
     while (parent != null) {
       ancestors.push(parent);
-      parent = this.findNode(parent.parent_id)
+      parent = this.findNode(parent.parent_id);
     }
 
     if (this.checklistSelection.isSelected(node)) {
       ancestors.forEach(anc => {
         const parentNode = this.findNode(anc.id);
-        this.checklistSelection.select(parentNode)
+        this.checklistSelection.select(parentNode);
       });
     } else {
       ancestors.forEach(anc => {
         const parentNode = this.findNode(anc.id);
         if (this.numSelectedDescendants(parentNode) < 1) {
-          this.checklistSelection.deselect(parentNode)
+          this.checklistSelection.deselect(parentNode);
         }
-      })
+      });
     }
 
     this._updateModelCategories();

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -43,6 +43,8 @@ export class ApiService {
     adminNoteList: '/api/admin_note',
     category: '/api/category/<id>',
     categorybyresource: '/api/resource/<resource_id>/category',
+    categorybylocation: '/api/location/<location_id>/category',
+    categorybyevent: '/api/event/<event_id>/category',
     categorybystudy: '/api/study/<study_id>/category',
     categorylist: '/api/category',
     data_transfer_log: '/api/data_transfer_log',
@@ -368,6 +370,20 @@ export class ApiService {
   /** Update ResourceCategory */
   updateResourceCategories(resource_id: number, selectedCategories: ResourceCategory[]) {
     const url = this._endpointUrl('categorybyresource').replace('<resource_id>', resource_id.toString());
+    return this.httpClient.post<ResourceCategory>(url, selectedCategories)
+      .pipe(catchError(this._handleError));
+  }
+
+  /** Update LocationCategory */
+  updateLocationCategories(location_id: number, selectedCategories: ResourceCategory[]) {
+    const url = this._endpointUrl('categorybylocation').replace('<location_id>', location_id.toString());
+    return this.httpClient.post<ResourceCategory>(url, selectedCategories)
+      .pipe(catchError(this._handleError));
+  }
+
+  /** Update EventCategory */
+  updateEventCategories(event_id: number, selectedCategories: ResourceCategory[]) {
+    const url = this._endpointUrl('categorybyevent').replace('<event_id>', event_id.toString());
     return this.httpClient.post<ResourceCategory>(url, selectedCategories)
       .pipe(catchError(this._handleError));
   }

--- a/frontend/src/app/contact-item/contact-item.component.html
+++ b/frontend/src/app/contact-item/contact-item.component.html
@@ -19,7 +19,7 @@
   </div>
   <div class="contact-item-detail" *ngIf="contactItem.type && (contactItem.type === 'link')">
     <ng-container *ngFor="let d of contactItem.details">
-      <a *ngIf="isNotEmpty(d)" href="{{d}}">{{d}}</a>
+      <a *ngIf="isNotEmpty(d)" target="_blank" href="{{d}}">{{d}}</a>
     </ng-container>
   </div>
 </div>

--- a/frontend/src/app/resource-form/resource-form.component.ts
+++ b/frontend/src/app/resource-form/resource-form.component.ts
@@ -379,8 +379,7 @@ export class ResourceFormComponent implements OnInit {
     const resourceType = this.model.type.charAt(0).toUpperCase() + this.model.type.slice(1);
 
     if (this.form.valid) {
-      if (this.createNew) {
-        this.createNew = false;
+      if (this.createNew && !this.model.id) {
         this.updateOrganization(() => this.updateAndClose(this.api[`add${resourceType}`](this.model)));
       } else {
         this.updateOrganization(() => this.updateAndClose(this.api[`update${resourceType}`](this.model)));

--- a/frontend/src/app/resource-form/resource-form.component.ts
+++ b/frontend/src/app/resource-form/resource-form.component.ts
@@ -338,6 +338,8 @@ export class ResourceFormComponent implements OnInit {
   }
 
   updateResourceCategories(resource_id) {
+    const resourceType = this.model.type.charAt(0).toUpperCase() + this.model.type.slice(1);
+
     const selectedCategories: ResourceCategory[] = [];
     this.model.categories.forEach((isSelected, i) => {
       if (isSelected === true) {
@@ -348,7 +350,7 @@ export class ResourceFormComponent implements OnInit {
         });
       }
     });
-    return this.api.updateResourceCategories(resource_id, selectedCategories);
+    return this.api[`update${resourceType}Categories`](resource_id, selectedCategories);
   }
 
   updateOrganization(callback: Function) {

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -1,29 +1,45 @@
 <div *ngIf="currentUser && currentUser.permissions.includes('publish_resource')">
   <h1>Topics Taxonomy</h1>
   <p>To add a topic, click the plus sign next to the parent topic and fill in the name</p>
-  <p>To delete topics, select the check boxes next to the ones you wish to delete and click the delete button</p>
+  <p>To delete a topic, use the button directly next to the topic; it is only possible to delete one topic at a time and only possible to delete topics with no associated children topics.</p>
   <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select taxonomy-admin">
     <!-- Child node-->
     <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
       <li class="mat-tree-node">
         <!-- use a disabled button to provide padding for tree leaf -->
         <button disabled mat-icon-button></button>
-        <mat-checkbox
-          (change)="toggleNode(node)"
-          [checked]="checklistSelection.isSelected(node)"
-        >{{node.name}} ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</mat-checkbox>
+        {{node.name}}
+        <button mat-button [routerLink]="[ '/search' ]" [queryParams]="{'category': node.id}">({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</button>
         <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
+        <button
+          type="button"
+          mat-flat-button
+          *ngIf="!showConfirmDelete"
+          (click)="showDelete(node)"
+          color="warn"
+        >Delete {{node.name}}</button>
+
+        <button
+          *ngIf="showConfirmDelete && (node.id===nodeToDelete.id)"
+          type="button"
+          mat-flat-button
+          (click)="deleteNode(node)"
+          color="warn"
+        >Permanently Delete {{node.name}}!!!
+        </button>
       </li>
     </mat-tree-node>
 
     <!--New Item Node-->
-    <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
-      <button mat-icon-button disabled></button>
-      <mat-form-field>
-        <mat-label>New item...</mat-label>
-        <input matInput #itemValue placeholder="Ex. Lettuce">
-      </mat-form-field>
-      <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
+    <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodeToggle>
+      <li>
+        <button mat-icon-button disabled></button>
+        <mat-form-field>
+          <mat-label>New item...</mat-label>
+          <input matInput #itemValue placeholder="Ex. Topic Name">
+        </mat-form-field>
+        <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
+      </li>
     </mat-tree-node>
 
     <!-- Parent node -->
@@ -40,19 +56,8 @@
               {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
             </mat-icon>
           </button>
-
-          <mat-checkbox
-            (change)="toggleNode(node)"
-            [checked]="checklistSelection.isSelected(node)"
-          >
-              <span
-                *ngIf="numSelectedDescendants(node)"
-                matBadge="{{numSelectedDescendants(node)}}"
-                matBadgeColor="accent"
-                matBadgeOverlap="false"
-              >{{node.name}} ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</span>
-            <span *ngIf="!numSelectedDescendants(node)">{{node.name}} ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</span>
-          </mat-checkbox>
+          {{node.name}}
+          <button mat-button [routerLink]="[ '/search' ]" [queryParams]="{'category': node.id}">({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</button>
           <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
         </div>
         <ul [class.tree-select-invisible]="!treeControl.isExpanded(node)">
@@ -61,29 +66,4 @@
       </li>
     </mat-nested-tree-node>
   </mat-tree>
-
-  <div
-    class="button-row"
-    fxLayout="row"
-    fxLayoutGap="2em"
-  >
-    <button
-      type="button"
-      mat-flat-button
-      *ngIf="!showConfirmDelete"
-      (click)="showDelete()"
-      color="warn"
-      id="delete-button"
-    >Delete Selected Topics</button>
-
-    <button
-      *ngIf="showConfirmDelete"
-      id="confirm_delete"
-      type="button"
-      mat-flat-button
-      (click)="onDelete()"
-      color="warn"
-    >Permanently Delete Selected Topics!!!
-    </button>
-  </div>
 </div>

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.html
@@ -1,49 +1,64 @@
 <div *ngIf="currentUser && currentUser.permissions.includes('publish_resource')">
   <h1>Topics Taxonomy</h1>
   <p>To add a topic, click the plus sign next to the parent topic and fill in the name</p>
-  <p>To delete a topic, use the button directly next to the topic; it is only possible to delete one topic at a time and only possible to delete topics with no associated children topics.</p>
+  <p>To delete a topic, use the button directly next to the topic; it is only possible to delete one topic at a time and
+    only possible to delete topics with no associated children topics.</p>
   <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="tree-select taxonomy-admin">
     <!-- Child node-->
-    <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+    <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
       <li class="mat-tree-node">
         <!-- use a disabled button to provide padding for tree leaf -->
         <button disabled mat-icon-button></button>
-        {{node.name}}
-        <button mat-button [routerLink]="[ '/search' ]" [queryParams]="{'category': node.id}">({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</button>
-        <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
-        <button
-          type="button"
-          mat-flat-button
-          *ngIf="!showConfirmDelete"
-          (click)="showDelete(node)"
-          color="warn"
-        >Delete {{node.name}}</button>
-
-        <button
-          *ngIf="showConfirmDelete && (node.id===nodeToDelete.id)"
-          type="button"
-          mat-flat-button
-          (click)="deleteNode(node)"
-          color="warn"
-        >Permanently Delete {{node.name}}!!!
+        <button matTreeNodeToggle mat-button>{{node.name}}</button>
+        <a [queryParams]="{'category': node.id}" [routerLink]="[ '/search' ]" class="associated-records">
+          ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)
+        </a>
+        <button (click)="addNewItem(node)" mat-icon-button color="primary" [matTooltip]="'Add sub-category to ' + node.name">
+          <mat-icon>add_circle</mat-icon>
         </button>
+        <button
+          (click)="showDelete(node)"
+          *ngIf="!showConfirmDelete"
+          color="warn"
+          mat-icon-button
+          type="button"
+          [matTooltip]="'Delete ' + node.name"
+        >
+          <mat-icon>delete</mat-icon>
+        </button>
+
+        <ng-container *ngIf="showConfirmDelete && (node.id===nodeToDelete.id)">
+          <button
+            (click)="deleteNode(node)"
+            color="warn"
+            mat-flat-button
+            type="button"
+          >Permanently Delete {{node.name}}!!!
+          </button>
+          <button
+            (click)="cancelDelete()"
+            mat-flat-button
+            type="button"
+          >Cancel
+          </button>
+        </ng-container>
+
       </li>
     </mat-tree-node>
 
     <!--New Item Node-->
-    <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodeToggle>
-      <li>
-        <button mat-icon-button disabled></button>
-        <mat-form-field>
-          <mat-label>New item...</mat-label>
-          <input matInput #itemValue placeholder="Ex. Topic Name">
-        </mat-form-field>
-        <button mat-button (click)="saveNode(node, itemValue.value)">Save</button>
-      </li>
+    <mat-tree-node *matTreeNodeDef="let node; when: hasNoContent" matTreeNodePadding>
+      <button disabled mat-icon-button></button>
+      <mat-form-field>
+        <mat-label>New item...</mat-label>
+        <input #itemValue matInput placeholder="Ex. Topic Name">
+      </mat-form-field>
+      <button (click)="saveNode(node, itemValue.value)" mat-button color="primary">Save</button>
+      <button (click)="cancelAdd()" mat-button>Cancel</button>
     </mat-tree-node>
 
     <!-- Parent node -->
-    <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
+    <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild" matTreeNodePadding>
       <li>
         <div class="mat-tree-node">
           <button
@@ -56,9 +71,13 @@
               {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
             </mat-icon>
           </button>
-          {{node.name}}
-          <button mat-button [routerLink]="[ '/search' ]" [queryParams]="{'category': node.id}">({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)</button>
-          <button mat-icon-button (click)="addNewItem(node)"><mat-icon>add</mat-icon></button>
+          <button matTreeNodeToggle mat-button>{{node.name}}</button>
+          <a [queryParams]="{'category': node.id}" [routerLink]="[ '/search' ]" class="associated-records">
+            ({{node.study_count + node.event_count + node.location_count + node.resource_count}} associated records)
+          </a>
+          <button (click)="addNewItem(node)" mat-icon-button [matTooltip]="'Add sub-category to ' + node.name">
+            <mat-icon>add_circle</mat-icon>
+          </button>
         </div>
         <ul [class.tree-select-invisible]="!treeControl.isExpanded(node)">
           <ng-container matTreeNodeOutlet></ng-container>

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.scss
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.scss
@@ -13,3 +13,8 @@
     outline: none !important;
   }
 }
+
+.associated-records {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -71,12 +71,12 @@ export class TaxonomyAdminComponent implements OnInit {
     });
   }
 
-  showDelete(node:Category) {
+  showDelete(node: Category) {
     this.showConfirmDelete = true;
     this.nodeToDelete = node;
   }
 
-  deleteNode(node:Category) {
+  deleteNode(node: Category) {
     this.api.deleteCategory(node.id).subscribe(cat => {
       this.showConfirmDelete = false;
       this.nodeToDelete = null;

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -20,6 +20,7 @@ export class TaxonomyAdminComponent implements OnInit {
   dataLoaded = false;
   nodes = {};
   showConfirmDelete = false;
+  nodeToDelete: Category;
   currentUser: User;
 
   /** The selection for checklist */
@@ -48,21 +49,6 @@ export class TaxonomyAdminComponent implements OnInit {
     return (node.children && (node.children.length > 0));
   }
 
-  numSelectedDescendants(node: Category): number {
-    const descendants: Category[] = this.treeControl.getDescendants(node);
-    const selectedDescendants = descendants.filter(d => this.checklistSelection.isSelected(d));
-    return selectedDescendants.length;
-  }
-
-  /** Toggle the category item selection. Select/deselect all the descendants node */
-  toggleNode(node: Category): void {
-    this.checklistSelection.toggle(node);
-    const descendants = this.treeControl.getDescendants(node);
-    this.checklistSelection.isSelected(node)
-      ? this.checklistSelection.select(...descendants)
-      : this.checklistSelection.deselect(...descendants);
-  }
-
   hasNoContent = (_: number, _nodeData: Category) => _nodeData.name === '';
 
   /** Select the category so we can insert the new item. */
@@ -85,22 +71,16 @@ export class TaxonomyAdminComponent implements OnInit {
     });
   }
 
-  showDelete() {
+  showDelete(node:Category) {
     this.showConfirmDelete = true;
+    this.nodeToDelete = node;
   }
 
-  onDelete() {
-    let itemsProcessed = 0;
-    this.checklistSelection.selected.forEach((cat, index, array) => {
-      this.api.deleteCategory(cat.id).subscribe(c => {
-        itemsProcessed++;
-        if (itemsProcessed === array.length) {
-          this.treeControl.collapseAll();
-          this.getCategoryTree();
-          window.scroll(0, 0);
-          this.showConfirmDelete = false;
-        }
-      });
+  deleteNode(node:Category) {
+    this.api.deleteCategory(node.id).subscribe(cat => {
+      this.showConfirmDelete = false;
+      this.nodeToDelete = null;
+      this.getCategoryTree();
     });
   }
 

--- a/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
+++ b/frontend/src/app/taxonomy-admin/taxonomy-admin.component.ts
@@ -63,15 +63,12 @@ export class TaxonomyAdminComponent implements OnInit {
     this.dataSource.data = this.insertNewChildNode(node, this.dataSource.data);
     this.refreshTree();
     this.treeControl.expand(node);
-    const el: HTMLElement = document.querySelector('.global-footer');
-    window.scroll(0, el.offsetTop);
   }
 
   /** Save the node to database */
   saveNode(node: Category, itemValue: string) {
     node.name = itemValue;
     this.api.addCategory(node).subscribe(cat => {
-      this.treeControl.collapseAll();
       this.getCategoryTree();
       window.scroll(0, 0);
     });
@@ -116,7 +113,7 @@ export class TaxonomyAdminComponent implements OnInit {
     if (cats && cats.length > 0) {
       const parentIndex = cats.findIndex(c => c.id === parentNode.id);
       if (parentIndex !== - 1) {
-        cats[parentIndex].children.push({name: '', parent: parentNode, parent_id: parentNode.id});
+        cats[parentIndex].children.push({name: '', parent_id: parentNode.id});
         return cats;
       } else {
         return cats.map(cat => {


### PR DESCRIPTION
This PR focuses on bugs and changes to do with topics. 

- The topics admin area no longer allows multiple deletes. Now only children with no descendants can be deleted, one at a time.
- The topics selection form field has new logic: only children with no descendants can be selected - and their parents are automatically selected/deselected along with them.
- Topics were not getting set on the search records until a second save/edit. This bug is fixed by updating the search records when resource_categories are saved.
- The count on topics is based on the type of resource being set in the resource_category object -- but all topics were going through the same endpoint, and the type was not being set at all. Now categories are being saved to their respective endpoints and the types are being set so that counts should be correct once all the existing ones with no type have been overwritten.