### PR TITLE
Feature/search enhancements - Fixes #357

### DIFF
--- a/backend/app/data_loader.py
+++ b/backend/app/data_loader.py
@@ -254,6 +254,18 @@ class DataLoader:
         db.session.commit()
         print("ZIP codes loaded.  There are now %i ZIP codes in the database." % db.session.query(ZipCode).count())
 
+    def load_partial_zip_codes(self):
+        items = []
+        with open(self.zip_code_coords_file, newline='') as csvfile:
+            reader = csv.reader(csvfile, delimiter=csv.excel.delimiter, quotechar=csv.excel.quotechar)
+            for _ in range(43000):  # skip the first 43000 rows
+                next(reader)
+            for row in reader:
+                items.append(ZipCode(id=row[0], latitude=row[1], longitude=row[2]))
+
+        db.session.bulk_save_objects(items)
+        db.session.commit()
+        print("ZIP codes loaded.  There are now %i ZIP codes in the database." % db.session.query(ZipCode).count())
 
     def get_org_by_name(self, org_name):
         organization = db.session.query(Organization).filter(Organization.name == org_name).first()

--- a/backend/app/model/geocode.py
+++ b/backend/app/model/geocode.py
@@ -1,0 +1,40 @@
+from app import app, db
+from app.model.zip_code import ZipCode
+from sqlalchemy.sql.expression import func
+import googlemaps
+
+
+class Geocode:
+
+    @staticmethod
+    def get_geocode(address_dict):
+
+        if 'TESTING' in app.config and app.config['TESTING']:
+            z = db.session.query(ZipCode).order_by(func.random()).first()
+            print("TEST:  Pretending to get the geocode and setting lat/lng to  %s - %s" % (z.latitude, z.longitude))
+            return {'lat': z.latitude, 'lng': z.longitude}
+
+        else:
+            api_key = app.config.get('GOOGLE_MAPS_API_KEY')
+            gmaps = googlemaps.Client(key=api_key)
+            lat = None
+            lng = None
+
+            # Check that location has at least a zip code
+            if address_dict['zip']:
+
+                # Look up the latitude and longitude using Google Maps API
+                address = ''
+                for value in address_dict:
+                    if address_dict[value] is not None:
+                        address = address + " " + address_dict[value]
+                geocode_result = gmaps.geocode(address)
+
+                if geocode_result is not None:
+                    if geocode_result[0] is not None:
+                        loc = geocode_result[0]['geometry']['location']
+                        lat = loc['lat']
+                        lng = loc['lng']
+                        print(address_dict, loc)
+
+            return {'lat': lat, 'lng': lng}

--- a/backend/app/model/zip_code.py
+++ b/backend/app/model/zip_code.py
@@ -1,4 +1,3 @@
-from flask_marshmallow import Schema
 from sqlalchemy import func
 
 from app import db

--- a/backend/app/resources/LocationEndpoint.py
+++ b/backend/app/resources/LocationEndpoint.py
@@ -8,6 +8,7 @@ from app import RestException, db, elastic_index, auth
 from app.model.event import Event
 from app.model.location import Location
 from app.model.resource_change_log import ResourceChangeLog
+from app.model.geocode import Geocode
 from app.schema.schema import LocationSchema
 from app.model.role import Permission
 from app.wrappers import requires_permission
@@ -43,6 +44,14 @@ class LocationEndpoint(flask_restful.Resource):
     def put(self, id):
         request_data = request.get_json()
         instance = db.session.query(Location).filter_by(id=id).first()
+        if instance.zip != request_data['zip'] \
+                or instance.street_address1 != request_data['street_address1'] \
+                or instance.latitude is None:
+            address_dict = {'street': request_data['street_address1'], 'city': request_data['city'],
+                            'state': request_data['state'], 'zip': request_data['zip']}
+            geocode = Geocode.get_geocode(address_dict=address_dict)
+            request_data['latitude'] = geocode['lat']
+            request_data['longitude'] = geocode['lng']
         updated, errors = self.schema.load(request_data, instance=instance)
         if errors: raise RestException(RestException.INVALID_OBJECT, details=errors)
         updated.last_updated = datetime.datetime.now()
@@ -52,7 +61,8 @@ class LocationEndpoint(flask_restful.Resource):
         self.log_update(location_id=updated.id, location_title=updated.title, change_type='edit')
         return self.schema.dump(updated)
 
-    def log_update(self, location_id, location_title, change_type):
+    @staticmethod
+    def log_update(location_id, location_title, change_type):
         log = ResourceChangeLog(resource_id=location_id, resource_title=location_title, user_id=g.user.id,
                                 user_email=g.user.email, type=change_type)
         db.session.add(log)
@@ -74,6 +84,11 @@ class LocationListEndpoint(flask_restful.Resource):
         request_data = request.get_json()
         try:
             load_result = self.locationSchema.load(request_data).data
+            address_dict = {'street': load_result.street_address1, 'city': load_result.city,
+                            'state': load_result.state, 'zip': load_result.zip}
+            geocode = Geocode.get_geocode(address_dict=address_dict)
+            load_result.latitude = geocode['lat']
+            load_result.longitude = geocode['lng']
             db.session.add(load_result)
             db.session.commit()
             elastic_index.add_document(load_result, 'Location', latitude=load_result.latitude, longitude=load_result.longitude)
@@ -83,7 +98,8 @@ class LocationListEndpoint(flask_restful.Resource):
             raise RestException(RestException.INVALID_OBJECT,
                                 details=load_result.errors)
 
-    def log_update(self, location_id, location_title, change_type):
+    @staticmethod
+    def log_update(location_id, location_title, change_type):
         log = ResourceChangeLog(resource_id=location_id, resource_title=location_title, user_id=g.user.id,
                                 user_email=g.user.email, type=change_type)
         db.session.add(log)

--- a/backend/app/resources/StudyEndpoint.py
+++ b/backend/app/resources/StudyEndpoint.py
@@ -64,3 +64,11 @@ class StudyListEndpoint(flask_restful.Resource):
         except ValidationError as err:
             raise RestException(RestException.INVALID_OBJECT,
                                 details=load_result.errors)
+
+
+class StudyByStatusListEndpoint(flask_restful.Resource):
+    studiesSchema = StudySchema(many=True)
+
+    def get(self, status):
+        studies = db.session.query(Study).filter_by(status=status)
+        return self.studiesSchema.dump(studies)

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -27,7 +27,7 @@ from app.resources.AdminNoteEndpoint import (
     AdminNoteListByResourceEndpoint,
     AdminNoteListEndpoint,
     AdminNoteEndpoint)
-from app.resources.StudyEndpoint import StudyEndpoint, StudyListEndpoint
+from app.resources.StudyEndpoint import StudyEndpoint, StudyListEndpoint, StudyByStatusListEndpoint
 from app.resources.InvestigatorEndpoint import InvestigatorEndpoint, InvestigatorListEndpoint
 from app.resources.SessionEndpoint import SessionEndpoint
 from app.resources.CategoryEndpoint import (
@@ -185,6 +185,7 @@ endpoints = [
 
     # Studies
     (StudyListEndpoint, "/study"),
+    (StudyByStatusListEndpoint, "/study/status/<status>"),
     (StudyEndpoint, "/study/<id>"),
     (CategoryByStudyEndpoint, "/study/<study_id>/category"),
     (StudyCategoryListEndpoint, "/study_category"),

--- a/frontend/e2e/src/app-page.po.ts
+++ b/frontend/e2e/src/app-page.po.ts
@@ -80,6 +80,15 @@ export class AppPage {
     expect(actualRoute).toEqual(route);
   }
 
+  async clickLinkToVariation(route: string) {
+    const selector = `[href="#${route}"]`;
+    this.waitForClickable(selector);
+    this.clickElement(selector);
+    const actualRoute = await this.getRoute();
+    const routeLength = route.length;
+    expect(actualRoute.substr(0, routeLength)).toEqual(route);
+  }
+
   getParagraphText() {
     return this.getElement('app-root h1').getText();
   }

--- a/frontend/e2e/src/use-cases/global-header.po.ts
+++ b/frontend/e2e/src/use-cases/global-header.po.ts
@@ -57,14 +57,14 @@ export class GlobalHeaderUseCases {
   }
 
   visitStudiesPage() {
-    this.page.clickLinkTo('/studies/currently_enrolling');
+    this.page.clickLinkToVariation('/studies');
     expect(this.page.getElements('.studies').count()).toEqual(1);
     expect(this.page.getElements('app-search-result').count()).toBeGreaterThan(1);
     this.page.clickLinkTo('/home');
   }
 
   visitResourcesPage() {
-    this.page.clickLinkTo('/search');
+    this.page.clickLinkToVariation('/search');
     this.page.waitForVisible('app-search-result');
 
     ['resource', 'location', 'event'].forEach(t => {

--- a/frontend/e2e/src/use-cases/search.po.ts
+++ b/frontend/e2e/src/use-cases/search.po.ts
@@ -100,7 +100,7 @@ export class SearchUseCases {
   }
 
   displayResourceAndClickChip() {
-    this.page.clickLinkTo('/search');
+    this.page.clickLinkToVariation('/search');
     this.page.waitForVisible('app-search-result');
     this.page.getElements('.result-item div a').first().click();
     this.page.waitForVisible('app-resource-detail');

--- a/frontend/e2e/src/use-cases/studies.po.ts
+++ b/frontend/e2e/src/use-cases/studies.po.ts
@@ -5,7 +5,7 @@ export class StudiesUseCases {
   }
 
   navigateToStudiesPage() {
-    this.page.clickLinkTo('/studies/currently_enrolling');
+    this.page.clickLinkToVariation('/studies');
     expect(this.page.getElements('.studies').count()).toEqual(1);
     expect(this.page.getElements('app-search-result').count()).toBeGreaterThan(1);
   }

--- a/frontend/src/app/_services/api/api.service.ts
+++ b/frontend/src/app/_services/api/api.service.ts
@@ -102,6 +102,7 @@ export class ApiService {
     studycategorylist: '/api/study_category',
     studyinquiry: '/api/study_inquiry',
     studylist: '/api/study',
+    studybystatuslist: '/api/study/status/<status>',
     user: '/api/user/<id>',
     userAdminNoteList: '/api/user/<user_id>/admin_note',
     userEmailLog: '/api/user/email_log/<id>',
@@ -207,6 +208,12 @@ export class ApiService {
   /** Get Studies */
   getStudies(): Observable<Study[]> {
     return this.httpClient.get<Study[]>(this._endpointUrl('studylist'))
+      .pipe(catchError(this._handleError));
+  }
+
+  /** Get Studies by Status */
+  getStudiesByStatus(status: string): Observable<Study[]> {
+    return this.httpClient.get<Study[]>(this._endpointUrl('studybystatuslist').replace('<status>', status))
       .pipe(catchError(this._handleError));
   }
 

--- a/frontend/src/app/header/header.component.html
+++ b/frontend/src/app/header/header.component.html
@@ -80,7 +80,7 @@
         </a></li>
         <li><a
           mat-button
-          [routerLink]="[ '/studies/currently_enrolling' ]"
+          [routerLink]="[ '/studies' ]"
           routerLinkActive="selected"
           id="studies-button"
         >

--- a/frontend/src/app/search/search.component.html
+++ b/frontend/src/app/search/search.component.html
@@ -74,7 +74,7 @@
 
             <div class="sort-order">
               <h3>Sort by</h3>
-              <mat-radio-group [ngModel]="selectedSort.name" (change)="newSortSelection($event)" fxLayout="column">
+              <mat-radio-group [ngModel]="selectedSort && selectedSort.name" (change)="newSortSelection($event)" fxLayout="column">
                 <mat-radio-button value="Relevance" *ngIf="query.words != ''">
                   Relevance to "{{query.words}}"
                   <button mat-button class="ghost"><mat-icon>code</mat-icon></button>
@@ -83,19 +83,19 @@
                   Distance
                   <span *ngIf="isZipCode(storedZip)">({{storedZip}})</span>
                   <span *ngIf="gpsEnabled && !isZipCode(storedZip)">(using GPS)</span>
-                  <button *ngIf="!this.noLocation && !this.setLocOpen" mat-button (click)="openSetLocation()" matTooltip="Set your location">
+                  <button [ngClass]="{'zipCodeSetButton': true, 'show': !this.noLocation && !this.setLocOpen}" mat-button (click)="openSetLocation()" matTooltip="Set your location">
                     <mat-icon>keyboard_arrow_down</mat-icon>
                   </button>
                 </mat-radio-button>
-                <div *ngIf="this.noLocation || this.setLocOpen" class="zipCodeSet" fxLayout="column">
-                  Or Set Your Location (restricted to VA, WV)
+                <div [ngClass]="{'zipCodeSet': true, 'show': this.noLocation || this.setLocOpen}" fxLayout="column">
+                  <p>Or Set Your Location (restricted to VA, WV)</p>
                   <mat-form-field>
                     <mat-label>ZIP Code</mat-label>
-                    <input matInput placeholder="ZIP Code" [(ngModel)]="updatedZip" (keyup.enter)="zipSubmit()">
+                    <input matInput placeholder="ZIP Code" [(ngModel)]="updatedZip" (keyup.enter)="zipSubmit($event)">
                   </mat-form-field>
                   <div fxLayout="row" fxLayoutGap="1em">
-                      <button mat-flat-button color="primary" (click)="zipSubmit()" id="btn_save">Save</button>
-                      <button *ngIf="gpsEnabled" mat-flat-button color="primary" (click)="useGPSLocation()" id="btn_gps">Use GPS instead</button>
+                      <button mat-flat-button color="primary" (click)="zipSubmit($event)" id="btn_save">Save</button>
+                      <button *ngIf="gpsEnabled" mat-flat-button color="primary" (click)="useGPSLocation($event)" id="btn_gps">Use GPS instead</button>
                   </div>
                 </div>
                 <mat-radio-button value="Updated">Recently Updated

--- a/frontend/src/app/search/search.component.scss
+++ b/frontend/src/app/search/search.component.scss
@@ -206,4 +206,25 @@ agm-map {
 
 .zipCodeSet {
   margin-left: 2em;
+  display: none;
+
+  ::ng-deep * {
+    display: none;
+  }
+
+  &.show {
+    display: inherit;
+
+    ::ng-deep * {
+      display: inherit;
+    }
+  }
+}
+
+.zipCodeSetButton {
+  opacity: 0;
+
+  &.show {
+    opacity: 1;
+  }
 }

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -332,26 +332,29 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
+
   newSortSelection(event) {
     this.reSort(event.value);
   }
 
   reSort(sortName: string) {
-    this.loading = true;
-    this.selectedSort = this.sortMethods.find(s => s.name === sortName);
-    this.query.start = this.selectedPageStart;
-    this.selectedPageStart = 0;
-    this.query.sort = this.selectedSort.sortQuery;
+    if (sortName) {
+      this.loading = true;
+      this.selectedSort = this.sortMethods.find(s => s.name === sortName);
+      this.query.start = this.selectedPageStart;
+      this.selectedPageStart = 0;
+      this.query.sort = this.selectedSort.sortQuery;
 
-    if (this.selectedSort.name === 'Event Date') {
-      this.selectType(HitType.EVENT.name);
-    } else if (this.selectedSort.name === 'Distance') {
-      this.loadMapLocation(() => this._updateDistanceSort());
-    } else {
-      if (this.updateUrl === true) {
-        this.updateUrlAndDoSearch(this.query);
+      if (this.selectedSort.name === 'Event Date') {
+        this.selectType(HitType.EVENT.name);
+      } else if (this.selectedSort.name === 'Distance') {
+        this.loadMapLocation(() => this._updateDistanceSort());
       } else {
-        this.doSearch();
+        if (this.updateUrl === true) {
+          this.updateUrlAndDoSearch(this.query);
+        } else {
+          this.doSearch();
+        }
       }
     }
   }
@@ -498,13 +501,15 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     this.setLocOpen = true;
   }
 
-  zipSubmit(): void {
+  zipSubmit($event: MouseEvent|KeyboardEvent): void {
+    $event.stopPropagation();
     localStorage.setItem('zipCode', this.updatedZip || '');
     this.setLocOpen = false;
     this.reSort('Distance');
   }
 
-  useGPSLocation(): void {
+  useGPSLocation($event: MouseEvent|KeyboardEvent): void {
+    $event.stopPropagation();
     localStorage.removeItem('zipCode');
     this.setLocOpen = false;
     this.reSort('Distance');

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -206,12 +206,15 @@ export class SearchComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.route.queryParamMap.subscribe(qParams => {
       this.query = this._queryParamsToQuery(qParams);
-      console.log('locating Map Results.');
       if (navigator.geolocation) {
         this.gpsEnabled = true;
       }
       this.loadMapLocation(f => {
-        this.reSort(this.query.words.length > 0 ? 'Relevance' : 'Distance');
+        if (qParams.get('sort')) {
+          this.reSort(qParams.get('sort'));
+        } else {
+          this.reSort(this.query.words.length > 0 ? 'Relevance' : 'Distance');
+        }
       });
     });
   }
@@ -337,7 +340,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     } else if (this.selectedSort.name === 'Distance') {
       this.loadMapLocation(() => this._updateDistanceSort());
     } else {
-      this.doSearch();
+      this.updateUrlAndDoSearch(this.query)
     }
   }
 
@@ -558,6 +561,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     queryParams.types = query.types;
     queryParams.ages = query.ages;
     queryParams.languages = query.languages;
+    queryParams.sort = this.selectedSort.name;
 
     if (query.hasOwnProperty('category') && query.category) {
       queryParams.category = query.category.id;
@@ -586,6 +590,9 @@ export class SearchComponent implements OnInit, OnDestroy {
           case('languages'):
             query.languages = qParams.getAll(key);
             break;
+          case('sort'):
+            query.sort = this.sortMethods.find(m => m.name===qParams.get(key)).sortQuery;
+            break;
           case('types'):
             query.types = qParams.getAll(key);
         }
@@ -601,7 +608,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     if (this.selectedSort.name === 'Distance') {
       this.selectedSort = distance_sort;
       this.query.sort = this.selectedSort.sortQuery;
-      this.doSearch();
+      this.updateUrlAndDoSearch(this.query);
     }
   }
 

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -106,7 +106,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       }
     },
   ];
-  updateUrl: boolean = false;
+  updateUrl = false;
   selectedSort: SortMethod;
   selectedPageStart = 0;
   pageEvent: PageEvent;
@@ -348,7 +348,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     } else if (this.selectedSort.name === 'Distance') {
       this.loadMapLocation(() => this._updateDistanceSort());
     } else {
-      if (this.updateUrl===true) {
+      if (this.updateUrl === true) {
         this.updateUrlAndDoSearch(this.query);
       } else {
         this.doSearch();
@@ -605,7 +605,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
             query.languages = qParams.getAll(key);
             break;
           case('sort'):
-            query.sort = this.sortMethods.find(m => m.name===qParams.get(key)).sortQuery;
+            query.sort = this.sortMethods.find(m => m.name === qParams.get(key)).sortQuery;
             break;
           case('pageStart'):
             this.selectedPageStart = Number(qParams.get(key));
@@ -626,7 +626,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.selectedSort.name === 'Distance') {
       this.selectedSort = distance_sort;
       this.query.sort = this.selectedSort.sortQuery;
-      if (this.updateUrl===true) {
+      if (this.updateUrl === true) {
         this.updateUrlAndDoSearch(this.query);
       } else {
         this.doSearch();
@@ -638,7 +638,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     this.query.start = 0;
     this.paginatorElement.firstPage();
 
-    if (this.updateUrl===true) {
+    if (this.updateUrl === true) {
       this.updateUrlAndDoSearch(this.query);
     } else {
       this.doSearch();

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -401,6 +401,7 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
       } else if (keepType === HitType.EVENT.name) {
         this.selectedSort = this.sortMethods.filter(s => s.name === 'Event Date')[0];
       }
+      this.query.sort = this.selectedSort.sortQuery;
     } else {
       this.selectedType = this.resourceTypes.find(t => t.name === HitType.ALL_RESOURCES.name);
       this.query.types = this.resourceTypesFilteredNames();

--- a/frontend/src/app/studies/studies.component.ts
+++ b/frontend/src/app/studies/studies.component.ts
@@ -49,8 +49,8 @@ export class StudiesComponent implements OnInit {
   }
 
   loadStudies() {
-    this.api.getStudies().subscribe(studies => {
-      this.studyHits = this._studiesToHits(studies.filter(s => s.status === this.selectedStatus.name));
+    this.api.getStudiesByStatus(this.selectedStatus.name).subscribe(studies => {
+      this.studyHits = this._studiesToHits(studies);
     });
   }
 

--- a/frontend/src/app/study-detail/study-detail.component.html
+++ b/frontend/src/app/study-detail/study-detail.component.html
@@ -21,12 +21,12 @@
       <p class="status">Study Status: {{ snakeToUpperCase(study.status) }}</p>
       <p>{{study.description}}</p>
       <p *ngIf="study.results_url"><b>Click <a target="_blank" href={{study.results_url}}>here</a> for the results</b></p>
-      <div *ngIf="study.participant_description">
+      <div *ngIf="study.status === 'currently_enrolling' && study.participant_description">
         <h2>Who we're looking for</h2>
         <p>{{study.participant_description}}</p>
       </div>
-      <div *ngIf="study.benefit_description">
-        <h2>Benefits of participating</h2>
+      <div *ngIf="study.status === 'currently_enrolling' && study.benefit_description">
+        <h2>Why Participate?</h2>
         <p>{{study.benefit_description}}</p>
       </div>
       <div *ngIf="study.study_investigators.length > 0">
@@ -39,7 +39,8 @@
         </div>
       </div>
       <div *ngIf="study.location">
-        <h2>Where does this study take place?</h2>
+        <h2 *ngIf="study.status === 'currently_enrolling' || study.status === 'study_in_progress'">Where does this study take place?</h2>
+        <h2 *ngIf="study.status === 'results_being_analyzed' || study.status === 'study_results_published'">Where did this study take place?</h2>
         <p>{{study.location}}</p>
         <p *ngIf="study.num_visits">Number of visits required for participation: {{study.num_visits}}</p>
       </div>


### PR DESCRIPTION
This PR addresses several issues around the broader topic of search UX. I'm thinking of these as part of, if not all of ticket #345  - we will have to revisit that ticket to see if anything else is needed once we have tested these fixes.

- **"Back Button": Add Sort and Pagination to search url.** Now users can navigate to a resource detail page and be delivered back to the correct sort and page of their search results when using their back button.
- **Happening Soon sort on Events selection.** When selecting Events, the Happening Soon sort was being selected, but not really sorting. Now it does.
- **Set Latitude/Longitude on new Events and Locations.** Now we are setting Lat/Lng for new events and locations when they are created so that they will actually show up on the map, function in the distance sort, and include a map on their detail pages. We also update lat/lng if the street address or zip code changes in edit (or if it isn't set at all).
- **Studies page performance.** Although unrelated to search, I've also include this little boost for the studies page here. Now there is a studies by status list endpoint that makes the studies page much more snappy. 
- **Study Detail page edits.** This also includes a few small edits to what displays on the study detail page based on the study status.