### PR TITLE
Bug/ga links & meta tags

### DIFF
--- a/backend/app/email_prompt_service.py
+++ b/backend/app/email_prompt_service.py
@@ -63,8 +63,7 @@ class EmailPromptService:
 
     def __send_prompting_email(self, user, send_method, log_type, days):
         current_studies = self.db.session.query(self.study_model).filter_by(status='currently_enrolling').all()
-        ga_link = '?utm_source=email&utm_medium=referral&utm_campaign=reset_password&utm_content=' \
-                  + days + '&utm_term=' + str(datetime.date.today())
+        ga_link = EmailService.generate_prompting_ga_link('prompting_study', days)
         for study in current_studies:
             study.link = self.app.config['SITE_URL'] + '/#/study/' + str(study.id) + ga_link
         tracking_code = send_method(user, current_studies, days)

--- a/backend/app/email_prompt_service.py
+++ b/backend/app/email_prompt_service.py
@@ -62,10 +62,17 @@ class EmailPromptService:
                     self.__send_prompting_email(rec, send_method, log_type, days)
 
     def __send_prompting_email(self, user, send_method, log_type, days):
+        campaign = 'prompting'
+        if log_type is 'confirm_email':
+            campaign = 'reset_password'
+        elif log_type is 'complete_registration_prompt':
+            campaign = 'create_yourprofile'
+        elif log_type is 'dependent_profile_prompt':
+            campaign = 'create_dependentprofile'
         current_studies = self.db.session.query(self.study_model).filter_by(status='currently_enrolling').all()
-        ga_link = EmailService.generate_google_analytics_link_content('currentstudies', days)
         for study in current_studies:
-            study.link = self.app.config['SITE_URL'] + '/#/study/' + str(study.id) + ga_link
+            study.link = self.app.config['SITE_URL'] + '/#/study/' + str(study.id) + \
+                         EmailService.generate_google_analytics_link_content(campaign + '_study' + str(study.id), days)
         tracking_code = send_method(user, current_studies, days)
         log = self.email_log_model(user_id=user.id, type=log_type, tracking_code=tracking_code)
         self.db.session.add(log)

--- a/backend/app/email_prompt_service.py
+++ b/backend/app/email_prompt_service.py
@@ -63,7 +63,7 @@ class EmailPromptService:
 
     def __send_prompting_email(self, user, send_method, log_type, days):
         current_studies = self.db.session.query(self.study_model).filter_by(status='currently_enrolling').all()
-        ga_link = EmailService.generate_prompting_ga_link('prompting_study', days)
+        ga_link = EmailService.generate_google_analytics_link_content('currentstudies', days)
         for study in current_studies:
             study.link = self.app.config['SITE_URL'] + '/#/study/' + str(study.id) + ga_link
         tracking_code = send_method(user, current_studies, days)

--- a/backend/app/email_service.py
+++ b/backend/app/email_service.py
@@ -88,7 +88,7 @@ class EmailService:
                                     forgot_pass_url=self.app.config['FRONTEND_FORGOT_PASSWORD'] + ga_link,
                                     tracking_code=tracking_code,
                                     current_studies=current_studies,
-                                    studies_url=self.site_url + '/#/studies' + studies_ga_link)
+                                    studies_url=self.site_url + '/#/studies/currently_enrolling' + studies_ga_link)
 
         html_body = render_template("confirm_email.html",
                                     user=user, confirm_url=confirm_url,
@@ -96,7 +96,7 @@ class EmailService:
                                     logo_url=logo_url,
                                     tracking_code=tracking_code,
                                     current_studies=current_studies,
-                                    studies_url=self.site_url + '/#/studies' + studies_ga_link)
+                                    studies_url=self.site_url + '/#/studies/currently_enrolling' + studies_ga_link)
 
         self.send_email(subject,
                         recipients=[user.email], text_body=text_body, html_body=html_body)
@@ -159,7 +159,9 @@ class EmailService:
                                     tracking_code=tracking_code)
 
         self.send_email(subject,
-                        recipients=[study.coordinator_email, 'autismdrive@virginia.edu'], text_body=text_body, html_body=html_body)
+                        recipients=[study.coordinator_email, 'autismdrive@virginia.edu'],
+                        text_body=text_body,
+                        html_body=html_body)
 
         return tracking_code
 
@@ -187,7 +189,7 @@ class EmailService:
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
                                         forgot_pass_url=self.app.config['FRONTEND_FORGOT_PASSWORD'] + ga_link,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
+                                        studies_url=self.site_url + '/#/studies/currently_enrolling' + studies_ga_link)
 
             html_body = render_template("complete_registration_email.html",
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
@@ -195,7 +197,7 @@ class EmailService:
                                         logo_url=logo_url,
                                         tracking_code=tracking_code,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
+                                        studies_url=self.site_url + '/#/studies/currently_enrolling' + studies_ga_link)
 
             self.send_email(subject, recipients=[user.email], text_body=text_body, html_body=html_body)
 
@@ -213,7 +215,7 @@ class EmailService:
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
                                         forgot_pass_url=self.app.config['FRONTEND_FORGOT_PASSWORD'] + ga_link,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
+                                        studies_url=self.site_url + '/#/studies/currently_enrolling' + studies_ga_link)
 
             html_body = render_template("complete_dependent_profile_email.html",
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
@@ -221,7 +223,7 @@ class EmailService:
                                         logo_url=logo_url,
                                         tracking_code=tracking_code,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
+                                        studies_url=self.site_url + '/#/studies/currently_enrolling' + studies_ga_link)
 
             self.send_email(subject, recipients=[user.email], text_body=text_body, html_body=html_body)
 

--- a/backend/app/email_service.py
+++ b/backend/app/email_service.py
@@ -80,7 +80,7 @@ class EmailService:
         role = '' + user.role.name + '/'
 
         ga_link = self.generate_google_analytics_link_content('reset_password', days)
-        studies_ga_link = self.generate_google_analytics_link_content('currentstudies', days)
+        studies_ga_link = self.generate_google_analytics_link_content('reset_password_studies', days)
         subject = "Autism DRIVE: Confirm Email"
         confirm_url = self.app.config['FRONTEND_EMAIL_RESET'] + role + token + ga_link
         text_body = render_template("confirm_email.txt",
@@ -182,7 +182,7 @@ class EmailService:
             tracking_code = self.tracking_code()
 
             ga_link = self.generate_google_analytics_link_content('create_yourprofile', days)
-            studies_ga_link = self.generate_google_analytics_link_content('currentstudies', days)
+            studies_ga_link = self.generate_google_analytics_link_content('create_yourprofile_studies', days)
             subject = "Autism DRIVE: Complete Your Registration"
             logo_url = self.api_url + '/api/track/' + str(user.id) + '/' + tracking_code + '/UVA_STAR-logo.png'
             text_body = render_template("complete_registration_email.txt",
@@ -208,7 +208,7 @@ class EmailService:
             tracking_code = self.tracking_code()
 
             ga_link = self.generate_google_analytics_link_content('create_dependentprofile', days)
-            studies_ga_link = self.generate_google_analytics_link_content('currentstudies', days)
+            studies_ga_link = self.generate_google_analytics_link_content('create_dependentprofile_studies', days)
             subject = "Autism DRIVE: Complete Your Dependent's Profile"
             logo_url = self.api_url + '/api/track/' + str(user.id) + '/' + tracking_code + '/UVA_STAR-logo.png'
             text_body = render_template("complete_dependent_profile_email.txt",

--- a/backend/app/email_service.py
+++ b/backend/app/email_service.py
@@ -79,8 +79,7 @@ class EmailService:
         token = ts.dumps(user.email, salt='email-reset-key')
         role = '' + user.role.name + '/'
 
-        ga_link = '?utm_source=email&utm_medium=referral&utm_campaign=reset_password&utm_content='\
-                  + days + '&utm_term=' + str(datetime.date.today())
+        ga_link = self.generate_prompting_ga_link('reset_password', days)
         subject = "Autism DRIVE: Confirm Email"
         confirm_url = self.app.config['FRONTEND_EMAIL_RESET'] + role + token + ga_link
         text_body = render_template("confirm_email.txt",
@@ -179,8 +178,7 @@ class EmailService:
         with self.app.app_context(), self.app.test_request_context():
             tracking_code = self.tracking_code()
 
-            ga_link = '?utm_source=email&utm_medium=referral&utm_campaign=create_yourprofile&utm_content=' \
-                      + days + '&utm_term=' + str(datetime.date.today())
+            ga_link = self.generate_prompting_ga_link('create_yourprofile', days)
             subject = "Autism DRIVE: Complete Your Registration"
             logo_url = self.api_url + '/api/track/' + str(user.id) + '/' + tracking_code + '/UVA_STAR-logo.png'
             text_body = render_template("complete_registration_email.txt",
@@ -205,8 +203,8 @@ class EmailService:
         with self.app.app_context(), self.app.test_request_context():
             tracking_code = self.tracking_code()
 
-            ga_link = '?utm_source=email&utm_medium=referral&utm_campaign=create_dependentprofile&utm_content=' \
-                      + days + '&utm_term=' + str(datetime.date.today())
+            ga_link = self.generate_prompting_ga_link('create_dependentprofile', days)
+
             subject = "Autism DRIVE: Complete Your Dependent's Profile"
             logo_url = self.api_url + '/api/track/' + str(user.id) + '/' + tracking_code + '/UVA_STAR-logo.png'
             text_body = render_template("complete_dependent_profile_email.txt",
@@ -226,3 +224,8 @@ class EmailService:
             self.send_email(subject, recipients=[user.email], text_body=text_body, html_body=html_body)
 
             return tracking_code
+
+    @staticmethod
+    def generate_prompting_ga_link(campaign, days):
+        return '?utm_source=email&utm_medium=referral&utm_campaign=' + campaign + '&utm_content=' \
+               + days + '&utm_term=' + str(datetime.date.today())

--- a/backend/app/email_service.py
+++ b/backend/app/email_service.py
@@ -79,7 +79,8 @@ class EmailService:
         token = ts.dumps(user.email, salt='email-reset-key')
         role = '' + user.role.name + '/'
 
-        ga_link = self.generate_prompting_ga_link('reset_password', days)
+        ga_link = self.generate_google_analytics_link_content('reset_password', days)
+        studies_ga_link = self.generate_google_analytics_link_content('currentstudies', days)
         subject = "Autism DRIVE: Confirm Email"
         confirm_url = self.app.config['FRONTEND_EMAIL_RESET'] + role + token + ga_link
         text_body = render_template("confirm_email.txt",
@@ -87,7 +88,7 @@ class EmailService:
                                     forgot_pass_url=self.app.config['FRONTEND_FORGOT_PASSWORD'] + ga_link,
                                     tracking_code=tracking_code,
                                     current_studies=current_studies,
-                                    studies_url=self.site_url + '/#/studies' + ga_link)
+                                    studies_url=self.site_url + '/#/studies' + studies_ga_link)
 
         html_body = render_template("confirm_email.html",
                                     user=user, confirm_url=confirm_url,
@@ -95,7 +96,7 @@ class EmailService:
                                     logo_url=logo_url,
                                     tracking_code=tracking_code,
                                     current_studies=current_studies,
-                                    studies_url=self.site_url + '/#/studies' + ga_link)
+                                    studies_url=self.site_url + '/#/studies' + studies_ga_link)
 
         self.send_email(subject,
                         recipients=[user.email], text_body=text_body, html_body=html_body)
@@ -178,14 +179,15 @@ class EmailService:
         with self.app.app_context(), self.app.test_request_context():
             tracking_code = self.tracking_code()
 
-            ga_link = self.generate_prompting_ga_link('create_yourprofile', days)
+            ga_link = self.generate_google_analytics_link_content('create_yourprofile', days)
+            studies_ga_link = self.generate_google_analytics_link_content('currentstudies', days)
             subject = "Autism DRIVE: Complete Your Registration"
             logo_url = self.api_url + '/api/track/' + str(user.id) + '/' + tracking_code + '/UVA_STAR-logo.png'
             text_body = render_template("complete_registration_email.txt",
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
                                         forgot_pass_url=self.app.config['FRONTEND_FORGOT_PASSWORD'] + ga_link,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + ga_link)
+                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
 
             html_body = render_template("complete_registration_email.html",
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
@@ -193,7 +195,7 @@ class EmailService:
                                         logo_url=logo_url,
                                         tracking_code=tracking_code,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + ga_link)
+                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
 
             self.send_email(subject, recipients=[user.email], text_body=text_body, html_body=html_body)
 
@@ -203,15 +205,15 @@ class EmailService:
         with self.app.app_context(), self.app.test_request_context():
             tracking_code = self.tracking_code()
 
-            ga_link = self.generate_prompting_ga_link('create_dependentprofile', days)
-
+            ga_link = self.generate_google_analytics_link_content('create_dependentprofile', days)
+            studies_ga_link = self.generate_google_analytics_link_content('currentstudies', days)
             subject = "Autism DRIVE: Complete Your Dependent's Profile"
             logo_url = self.api_url + '/api/track/' + str(user.id) + '/' + tracking_code + '/UVA_STAR-logo.png'
             text_body = render_template("complete_dependent_profile_email.txt",
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
                                         forgot_pass_url=self.app.config['FRONTEND_FORGOT_PASSWORD'] + ga_link,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + ga_link)
+                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
 
             html_body = render_template("complete_dependent_profile_email.html",
                                         profile_url=self.app.config['SITE_URL'] + '/#/profile' + ga_link,
@@ -219,13 +221,13 @@ class EmailService:
                                         logo_url=logo_url,
                                         tracking_code=tracking_code,
                                         current_studies=current_studies,
-                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + ga_link)
+                                        studies_url=self.app.config['SITE_URL'] + '/#/studies' + studies_ga_link)
 
             self.send_email(subject, recipients=[user.email], text_body=text_body, html_body=html_body)
 
             return tracking_code
 
     @staticmethod
-    def generate_prompting_ga_link(campaign, days):
+    def generate_google_analytics_link_content(campaign, days):
         return '?utm_source=email&utm_medium=referral&utm_campaign=' + campaign + '&utm_content=' \
                + days + '&utm_term=' + str(datetime.date.today())

--- a/frontend/src/app/_routing/routing.module.ts
+++ b/frontend/src/app/_routing/routing.module.ts
@@ -29,12 +29,12 @@ import {Covid19ResourcesComponent} from '../covid19-resources/covid19-resources.
 
 const routes: Routes = [
   {path: '', redirectTo: 'home', pathMatch: 'full', canActivate: [NotMirroredGuard]},
-  {path: 'home', component: HomeComponent, data: {title: 'Welcome Autism DRIVE'}, canActivate: [NotMirroredGuard]},
-  {path: 'uva-education', component: UvaEducationComponent, data: {title: 'UVA Education'}, canActivate: [NotMirroredGuard]},
+  {path: 'home', component: HomeComponent, data: {title: 'Welcome to Autism DRIVE'}, canActivate: [NotMirroredGuard]},
+  {path: 'uva-education', component: UvaEducationComponent, data: {title: 'Autism DRIVE UVA Education'}, canActivate: [NotMirroredGuard]},
   {
     path: 'about',
     component: AboutComponent,
-    data: {title: 'Enroll in an Autism DRIVE Study'},
+    data: {title: 'About Autism DRIVE'},
     canActivate: [NotMirroredGuard]
   },
   {
@@ -66,9 +66,9 @@ const routes: Routes = [
     canActivate: [AuthGuard, NotMirroredGuard]
   },
   {path: 'register', component: RegisterComponent, data: {title: 'Create an Autism DRIVE Account', hideHeader: true}},
-  {path: 'event/:resourceId', component: ResourceDetailComponent, data: {title: 'Event Details'}},
-  {path: 'location/:resourceId', component: ResourceDetailComponent, data: {title: 'Location Details'}},
-  {path: 'resource/:resourceId', component: ResourceDetailComponent, data: {title: 'Resource Details'}},
+  {path: 'event/:resourceId', component: ResourceDetailComponent, data: {title: 'Autism DRIVE Event Details'}},
+  {path: 'location/:resourceId', component: ResourceDetailComponent, data: {title: 'Autism DRIVE Location Details'}},
+  {path: 'resource/:resourceId', component: ResourceDetailComponent, data: {title: 'Autism DRIVE Resource Details'}},
   {
     path: ':resourceType/:resourceId/edit',
     component: ResourceFormComponent,
@@ -81,8 +81,8 @@ const routes: Routes = [
     data: {title: 'Add Resource', roles: ['admin', 'editor']},
     canActivate: [RoleGuard]
   },
-  {path: 'covid19-resources', component: Covid19ResourcesComponent, data: {title: 'COVID-19 Resources'}},
-  {path: 'covid19-resources/:category', component: Covid19ResourcesComponent, data: {title: 'COVID-19 Resources'}},
+  {path: 'covid19-resources', component: Covid19ResourcesComponent, data: {title: 'Autism DRIVE COVID-19 Resources'}},
+  {path: 'covid19-resources/:category', component: Covid19ResourcesComponent, data: {title: 'Autism DRIVE COVID-19 Resources'}},
   {path: 'studies', component: StudiesComponent, data: {title: 'Autism DRIVE Studies'}},
   {path: 'studies/:studyStatus', component: StudiesComponent, data: {title: 'Autism DRIVE Studies'}},  {
     path: 'studies/add',
@@ -90,7 +90,7 @@ const routes: Routes = [
     data: {title: 'Create an Autism DRIVE Study', roles: ['admin', ]},
     canActivate: [RoleGuard]
   },
-  {path: 'study/:studyId', component: StudyDetailComponent, data: {title: 'Study Details'}},
+  {path: 'study/:studyId', component: StudyDetailComponent, data: {title: 'Autism DRIVE Study Details'}},
   {
     path: 'study/edit/:studyId',
     component: StudyFormComponent,
@@ -104,12 +104,12 @@ const routes: Routes = [
   },
   {path: 'logout', component: LogoutComponent, data: {title: 'You have been logged out.', hideHeader: true}},
   {path: 'timedout', component: TimedoutComponent, data: {title: 'Your session has timed out.', hideHeader: true}},
-  {path: 'search', component: SearchComponent, data: {title: 'Search'}},
-  {path: 'search/:query', component: SearchComponent, data: {title: 'Search Resources'}},
+  {path: 'search', component: SearchComponent, data: {title: 'Search Autism DRIVE'}},
+  {path: 'search/:query', component: SearchComponent, data: {title: 'Search Autism DRIVE Resources'}},
   {
     path: 'admin',
     component: AdminHomeComponent,
-    data: {title: 'Admin Home', roles: ['admin', ]},
+    data: {title: 'Autism DRIVE Admin Home', roles: ['admin', ]},
     canActivate: [RoleGuard]
   },
   {

--- a/frontend/src/app/about/about.component.ts
+++ b/frontend/src/app/about/about.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { Meta } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-about',
@@ -9,8 +10,19 @@ import { Router } from '@angular/router';
 export class AboutComponent implements OnInit {
 
   constructor(
-    private router: Router
-  ) { }
+    private router: Router,
+    private meta: Meta,
+  ) {
+    this.meta.updateTag(
+      { property: 'og:image', content: location.origin + '/assets/about/hero.jpg' },
+      `property='og:image'`);
+    this.meta.updateTag(
+      { property: 'og:image:secure_url', content: location.origin + '/assets/about/hero.jpg' },
+      `property='og:image:secure_url'`);
+    this.meta.updateTag(
+      { name: 'twitter:image', content: location.origin + '/assets/about/hero.jpg' },
+      `name='twitter:image'`);
+  }
 
   ngOnInit() {
   }

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivationEnd, ActivationStart, Router } from '@angular/router';
+import {ActivatedRoute, ActivationEnd, ActivationStart, NavigationEnd, Router} from '@angular/router';
 import { User } from './_models/user';
 import { AuthenticationService } from './_services/api/authentication-service';
 import {ApiService} from './_services/api/api.service';
 import {GoogleAnalyticsService} from './google-analytics.service';
 import {ConfigService} from './_services/config.service';
+import {Meta} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
@@ -21,7 +22,10 @@ export class AppComponent implements OnInit {
     private api: ApiService,
     private router: Router,
     private googleAnalyticsService: GoogleAnalyticsService,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private meta: Meta,
+    private route: ActivatedRoute,
+
   ) {
     this.googleAnalyticsService.init();
     this.router.events.subscribe((e) => {
@@ -33,9 +37,26 @@ export class AppComponent implements OnInit {
       }
     });
     this.authenticationService.currentUser.subscribe(x => this.currentUser = x);
+    this.meta.addTags([
+      { property: 'og:url', content: location.origin },
+      { property: 'og:image', content: location.origin + '/assets/home/hero-family.jpg' },
+      { property: 'og:image:secure_url', content: location.origin + '/assets/home/hero-family.jpg' },
+      { name: 'twitter:image', content: location.origin + '/assets/home/hero-family.jpg' },
+    ]);
   }
 
   ngOnInit() {
+    this.router.events
+    .subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        const title = this.route.snapshot.firstChild.data.title;
+        if (title) {
+          this.meta.updateTag({ property: 'og:title', content: title }, `property='og:title'`);
+          this.meta.updateTag({ name: 'twitter:text:title', content: title }, `name='twitter:text:title'`);
+        }
+        this.meta.updateTag({ property: 'og:url', content: location.href }, `property='og:url'`);
+      }
+    });
   }
 
 }

--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -5,6 +5,7 @@ import {ApiService} from '../_services/api/api.service';
 import {NewsItem} from '../_models/news-item';
 import {HitType} from '../_models/hit_type';
 import {ConfigService} from '../_services/config.service';
+import {Meta} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-home',
@@ -18,7 +19,8 @@ export class HomeComponent implements OnInit {
   constructor(
     private api: ApiService,
     private router: Router,
-    private configService: ConfigService
+    private configService: ConfigService,
+    private meta: Meta,
   ) {
     this.api.getStudies().subscribe(all => {
       this.currentStudies = all.filter(s => s.status === 'currently_enrolling');
@@ -27,6 +29,15 @@ export class HomeComponent implements OnInit {
     if (this.configService.mirroring) {
       router.navigate(['mirrored']);
     }
+    this.meta.updateTag(
+        { property: 'og:image', content: location.origin + '/assets/home/hero-family.jpg' },
+        `property='og:image'`);
+    this.meta.updateTag(
+      { property: 'og:image:secure_url', content: location.origin + '/assets/home/hero-family.jpg' },
+      `property='og:image:secure_url'`);
+    this.meta.updateTag(
+      { name: 'twitter:image', content: location.origin + '/assets/home/hero-family.jpg' },
+      `name='twitter:image'`);
   }
 
   ngOnInit() {

--- a/frontend/src/app/register/register.component.ts
+++ b/frontend/src/app/register/register.component.ts
@@ -6,6 +6,7 @@ import { ApiService } from '../_services/api/api.service';
 import { User } from '../_models/user';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {GoogleAnalyticsService} from '../google-analytics.service';
+import {Meta} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-register',
@@ -39,7 +40,8 @@ export class RegisterComponent implements OnInit {
     private changeDetectorRef: ChangeDetectorRef,
     private router: Router,
     private route: ActivatedRoute,
-    private googleAnalytics: GoogleAnalyticsService
+    private googleAnalytics: GoogleAnalyticsService,
+    private meta: Meta,
   ) {
     this._stateSubject = new BehaviorSubject<string>('form');
     this.registerState = this._stateSubject.asObservable();
@@ -48,6 +50,15 @@ export class RegisterComponent implements OnInit {
       email: this.model['email'],
       role: 'User'
     });
+    this.meta.updateTag(
+        { property: 'og:image', content: location.origin + '/assets/join/hero.jpg' },
+        `property='og:image'`);
+    this.meta.updateTag(
+      { property: 'og:image:secure_url', content: location.origin + '/assets/join/hero.jpg' },
+      `property='og:image:secure_url'`);
+    this.meta.updateTag(
+      { name: 'twitter:image', content: location.origin + '/assets/join/hero.jpg' },
+      `name='twitter:image'`);
   }
 
   ngOnInit() {

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -15,6 +15,7 @@ import {ApiService} from '../_services/api/api.service';
 import {AuthenticationService} from '../_services/api/authentication-service';
 import {SearchService} from '../_services/api/search.service';
 import {GoogleAnalyticsService} from '../google-analytics.service';
+import {Meta} from '@angular/platform-browser';
 
 interface SortMethod {
   name: string;
@@ -158,7 +159,8 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     private googleAnalyticsService: GoogleAnalyticsService,
     private authenticationService: AuthenticationService,
     media: MediaMatcher,
-    private api: ApiService
+    private api: ApiService,
+    private meta: Meta,
   ) {
     this.authenticationService.currentUser.subscribe(x => this.currentUser = x);
     this._mobileQueryListener = () => this._updateFilterPanelState();
@@ -169,6 +171,15 @@ export class SearchComponent implements OnInit, AfterViewInit, OnDestroy {
     // tslint:disable-next-line:deprecation
     this.mobileQuery.addListener(this._mobileQueryListener);
     window.addEventListener('resize', this._mobileQueryListener);
+    this.meta.updateTag(
+        { property: 'og:image', content: window.location.origin + '/assets/home/hero-parent-child.jpg' },
+        `property='og:image'`);
+    this.meta.updateTag(
+      { property: 'og:image:secure_url', content: window.location.origin + '/assets/home/hero-parent-child.jpg' },
+      `property='og:image:secure_url'`);
+    this.meta.updateTag(
+      { name: 'twitter:image', content: window.location.origin + '/assets/home/hero-parent-child.jpg' },
+      `name='twitter:image'`);
   }
 
   @ViewChild(MatPaginator, {static: false})

--- a/frontend/src/app/studies/studies.component.ts
+++ b/frontend/src/app/studies/studies.component.ts
@@ -5,6 +5,7 @@ import {Study, StudyStatus} from '../_models/study';
 import {AuthenticationService} from '../_services/api/authentication-service';
 import {User} from '../_models/user';
 import {ActivatedRoute, Router} from '@angular/router';
+import {Meta} from '@angular/platform-browser';
 
 interface StudyStatusObj {
   name: string;
@@ -28,8 +29,18 @@ export class StudiesComponent implements OnInit {
     private authenticationService: AuthenticationService,
     private route: ActivatedRoute,
     private router: Router,
+    private meta: Meta,
   ) {
     this.authenticationService.currentUser.subscribe(x => this.currentUser = x);
+    this.meta.updateTag(
+        { property: 'og:image', content: location.origin + '/assets/studies/hero.jpg' },
+        `property='og:image'`);
+    this.meta.updateTag(
+      { property: 'og:image:secure_url', content: location.origin + '/assets/studies/hero.jpg' },
+      `property='og:image:secure_url'`);
+    this.meta.updateTag(
+      { name: 'twitter:image', content: location.origin + '/assets/studies/hero.jpg' },
+      `name='twitter:image'`);
     this.studyStatuses = Object.keys(StudyStatus).map(k => {
       return {name: k, label: StudyStatus[k]};
     });

--- a/frontend/src/app/uva-education/uva-education.component.ts
+++ b/frontend/src/app/uva-education/uva-education.component.ts
@@ -5,6 +5,7 @@ import {Resource} from '../_models/resource';
 import {User} from '../_models/user';
 import {ApiService} from '../_services/api/api.service';
 import {AuthenticationService} from '../_services/api/authentication-service';
+import {Meta} from '@angular/platform-browser';
 
 @Component({
   selector: 'app-uva-education',
@@ -21,8 +22,18 @@ export class UvaEducationComponent implements OnInit {
   constructor(
     private api: ApiService,
     private authenticationService: AuthenticationService,
+    private meta: Meta,
   ) {
     this.authenticationService.currentUser.subscribe(x => this.currentUser = x);
+    this.meta.updateTag(
+        { property: 'og:image', content: location.origin + '/assets/education/uva_education.jpg' },
+        `property='og:image'`);
+    this.meta.updateTag(
+      { property: 'og:image:secure_url', content: location.origin + '/assets/education/uva_education.jpg' },
+      `property='og:image:secure_url'`);
+    this.meta.updateTag(
+      { name: 'twitter:image', content: location.origin + '/assets/education/uva_education.jpg' },
+      `name='twitter:image'`);
     this.loadResources();
   }
 

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -10,6 +10,11 @@
     name="viewport"
     content="width=device-width, initial-scale=1"
   >
+  <meta property="og:site_name" content="Autism DRIVE" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Transform Outcomes. Together." />
+  <meta property="og:description" content="Transform Outcomes. Together. A centralized system for autism research & resources for individuals, families & professionals. " />
+  <meta name="twitter:text:title" content="Transform Outcomes. Together." />
   <link
     rel="icon"
     type="image/x-icon"


### PR DESCRIPTION
This PR tackles three issues -- two related to the google analytics content in links going out in the automated emails, and another related to meta tags for social media display.

- Update GA links: the links to individual studies that were going out in the automated mails were all setting the campaign to reset_password (whether it was in that email or one of the profile prompt emails). We took this opportunity to refine the campaigns for all the links. The main CTA links kept the same campaigns that we had assigned before. Now the studies links, however, have their own variations on that campaign name (the general studies link is now something like reset_password_studies; the individual studies include their study id in the campaign: reset_password_study123).
- Add method for generating the GA content: We got rid of some of the messy duplication in creating the google analytics content.
- Open Graph/Twitter meta tags: Adding these meta tags to the front end should create more engaging posts when the site is linked on social media. I expect there to be some iteration on this to get it fine-tuned to the team's liking, but this should give us a good starting point for testing. The titles are updated based on the route title, and the pictures are set on the main components to match the hero images for those pages.