### PR TITLE
Fixes 436 switched the api call to use status

### DIFF
--- a/frontend/src/app/home/home.component.ts
+++ b/frontend/src/app/home/home.component.ts
@@ -22,9 +22,9 @@ export class HomeComponent implements OnInit {
     private configService: ConfigService,
     private meta: Meta,
   ) {
-    this.api.getStudies().subscribe(all => {
-      this.currentStudies = all.filter(s => s.status === 'currently_enrolling');
-      this.newsItems = this._studiesToNewsItems(this.currentStudies);
+    this.api.getStudiesByStatus('currently_enrolling').subscribe(studies => {
+      this.currentStudies = studies;
+      this.newsItems = this._studiesToNewsItems(studies);
     });
     if (this.configService.mirroring) {
       router.navigate(['mirrored']);
@@ -46,7 +46,6 @@ export class HomeComponent implements OnInit {
   private _studiesToNewsItems(studies: Study[]): NewsItem[] {
     if (this.currentStudies && this.currentStudies.length > 0) {
       return studies
-        .sort((a, b) => (a.id < b.id) ? 1 : -1)
         .map((s, i) => {
           const n: NewsItem = {
             title: s.short_title || s.title,


### PR DESCRIPTION
With the changes the api call by status that we're using on the studies page, this  should make things more consistent, cleaner, and faster, with store/filtering studies on the homepage. 